### PR TITLE
Implement SourceTextReader

### DIFF
--- a/src/Compilers/Lua/Portable/Loretta.CodeAnalysis.Lua.csproj
+++ b/src/Compilers/Lua/Portable/Loretta.CodeAnalysis.Lua.csproj
@@ -43,7 +43,6 @@
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="Tsu" Version="2.1.1" />
-    <PackageReference Include="GParse" Version="5.0.0-alpha08" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Compilers/Lua/Portable/Parser/AbstractLexer.cs
+++ b/src/Compilers/Lua/Portable/Parser/AbstractLexer.cs
@@ -173,14 +173,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                     break;
             }
 
-            if (intern)
-            {
-                if (!_reader.TryGetInternedText(_strings, start, length, out var str))
-                    str = Intern(start, length);
-                return str;
-            }
-
-            return _text.ToString(new TextSpan(start, length));
+            return intern ? Intern(start, length) : _text.ToString(new TextSpan(start, length));
         }
 
         #endregion GetText

--- a/src/Compilers/Lua/Portable/Parser/AbstractLexer.cs
+++ b/src/Compilers/Lua/Portable/Parser/AbstractLexer.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text;
-using GParse.IO;
 using Loretta.CodeAnalysis.Text;
 using Loretta.Utilities;
 

--- a/src/Compilers/Lua/Portable/Parser/AbstractLexer.cs
+++ b/src/Compilers/Lua/Portable/Parser/AbstractLexer.cs
@@ -7,7 +7,7 @@ using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {
-    internal class AbstractLexer : IDisposable
+    internal class AbstractLexer
     {
         protected readonly SourceText _text;
         protected readonly SourceTextReader _reader;
@@ -24,11 +24,6 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
             // Lexer without the ICodeReader.
             _reader = new SourceTextReader(text);
             _strings = new StringTable();
-        }
-
-        public virtual void Dispose()
-        {
-            _reader.Dispose();
         }
 
         public int Length => _reader.Length;

--- a/src/Compilers/Lua/Portable/Parser/Lexer.Numbers.cs
+++ b/src/Compilers/Lua/Portable/Parser/Lexer.Numbers.cs
@@ -14,7 +14,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
             {
                 if (digit != '_')
                     builder.Append(digit);
-                _reader.Advance(1);
+                _reader.Position += 1;
             }
         }
 
@@ -22,7 +22,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
         {
             // Skip leading 0s
             while (_reader.Peek().GetValueOrDefault() == '0')
-                _reader.Advance(1);
+                _reader.Position += 1;
 
             var num = 0L;
             var digits = 0;
@@ -30,7 +30,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
             char digit;
             while (CharUtils.IsInRange('0', digit = _reader.Peek().GetValueOrDefault(), '1') || digit == '_')
             {
-                _reader.Advance(1);
+                _reader.Position += 1;
                 if (digit == '_')
                 {
                     hasUnderscores = true;
@@ -62,7 +62,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
         {
             // Skip leading 0s
             while (_reader.Peek().GetValueOrDefault() == '0')
-                _reader.Advance(1);
+                _reader.Position += 1;
 
             var num = 0L;
             var digits = 0;
@@ -70,7 +70,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
             char digit;
             while (CharUtils.IsInRange('0', digit = _reader.Peek().GetValueOrDefault(), '7') || digit == '_')
             {
-                _reader.Advance(1);
+                _reader.Position += 1;
                 if (digit == '_')
                 {
                     hasUnderscores = true;
@@ -173,7 +173,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                 {
                     if (digit != '_')
                         _builder.Append(digit);
-                    _reader.Advance(1);
+                    _reader.Position += 1;
                 }
             }
         }

--- a/src/Compilers/Lua/Portable/Parser/Lexer.ShortString.cs
+++ b/src/Compilers/Lua/Portable/Parser/Lexer.ShortString.cs
@@ -22,76 +22,81 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                     case '\\':
                     {
                         var escapeStart = _reader.Position;
-                        _reader.Advance(1);
+                        _reader.Position += 1;
 
                         switch (_reader.Peek())
                         {
                             case '\r':
-                                if (_reader.IsAt('\n', 1))
+                                if (_reader.IsAt(1, '\n'))
                                 {
-                                    _reader.Advance(2);
+                                    _reader.Position += 2;
                                     _builder.Append("\r\n");
                                 }
                                 else
                                 {
-                                    _reader.Advance(1);
+                                    _reader.Position += 1;
                                     _builder.Append('\r');
                                 }
                                 break;
 
                             case 'a':
-                                _reader.Advance(1);
+                                _reader.Position += 1;
                                 _builder.Append('\a');
                                 break;
 
                             case 'b':
-                                _reader.Advance(1);
+                                _reader.Position += 1;
                                 _builder.Append('\b');
                                 break;
 
                             case 'f':
-                                _reader.Advance(1);
+                                _reader.Position += 1;
                                 _builder.Append('\f');
                                 break;
 
                             case 'n':
-                                _reader.Advance(1);
+                                _reader.Position += 1;
                                 _builder.Append('\n');
                                 break;
 
                             case 'r':
-                                _reader.Advance(1);
+                                _reader.Position += 1;
                                 _builder.Append('\r');
                                 break;
 
                             case 't':
-                                _reader.Advance(1);
+                                _reader.Position += 1;
                                 _builder.Append('\t');
                                 break;
 
                             case 'v':
-                                _reader.Advance(1);
+                                _reader.Position += 1;
                                 _builder.Append('\v');
                                 break;
 
                             case '\\':
-                                _reader.Advance(1);
+                                _reader.Position += 1;
                                 _builder.Append('\\');
                                 break;
 
                             case '\n':
-                                _reader.Advance(1);
+                                _reader.Position += 1;
                                 _builder.Append('\n');
                                 break;
 
                             case '\'':
-                                _reader.Advance(1);
+                                _reader.Position += 1;
                                 _builder.Append('\'');
                                 break;
 
                             case '"':
-                                _reader.Advance(1);
+                                _reader.Position += 1;
                                 _builder.Append('"');
+                                break;
+
+                            case 'z':
+                                _reader.Position += 1;
+                                _reader.SkipWhile(c => c is '\f' or '\n' or '\r' or '\t' or '\v' or ' ');
                                 break;
 
                             case '0':
@@ -113,7 +118,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 
                             case 'x':
                             {
-                                _reader.Advance(1);
+                                _reader.Position += 1;
                                 var parsedCharInteger = parseHexadecimalInteger(escapeStart);
                                 if (parsedCharInteger != char.MaxValue)
                                     _builder.Append(parsedCharInteger);
@@ -126,7 +131,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                             default:
                             {
                                 // Skip the character after the escape.
-                                _reader.Advance(1);
+                                _reader.Position += 1;
                                 AddError(escapeStart, _reader.Position - escapeStart, ErrorCode.ERR_InvalidStringEscape);
                             }
                             break;
@@ -138,14 +143,14 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 
                     case '\r':
                     {
-                        if (_reader.IsAt('\n', 1))
+                        if (_reader.IsAt(1, '\n'))
                         {
-                            _reader.Advance(2);
+                            _reader.Position += 2;
                             _builder.Append("\r\n");
                         }
                         else
                         {
-                            _reader.Advance(1);
+                            _reader.Position += 1;
                             _builder.Append('\r');
                         }
 
@@ -155,7 +160,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 
                     case '\n':
                     {
-                        _reader.Advance(1);
+                        _reader.Position += 1;
                         _builder.Append('\n');
 
                         AddError(charStart, _reader.Position - charStart, ErrorCode.ERR_UnescapedLineBreakInString);
@@ -163,7 +168,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                     break;
 
                     default:
-                        _reader.Advance(1);
+                        _reader.Position += 1;
                         _builder.Append(peek);
                         break;
                 }
@@ -171,7 +176,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 
             if (_reader.IsNext(delim))
             {
-                _reader.Advance(1);
+                _reader.Position += 1;
             }
             else
             {
@@ -187,7 +192,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                 char ch;
                 while (readChars < 3 && CharUtils.IsDecimal(ch = _reader.Peek().GetValueOrDefault()))
                 {
-                    _reader.Advance(1);
+                    _reader.Position += 1;
                     num = (num * 10) + (ch - '0');
                     readChars++;
                 }
@@ -210,12 +215,12 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                     var peek = _reader.Peek().GetValueOrDefault();
                     if (CharUtils.IsDecimal(peek))
                     {
-                        _reader.Advance(1);
+                        _reader.Position += 1;
                         num = (byte) ((num << 4) | (peek - '0'));
                     }
                     else if (CharUtils.IsHexadecimal(peek))
                     {
-                        _reader.Advance(1);
+                        _reader.Position += 1;
                         num = (byte) ((num << 4) | (10 + CharUtils.AsciiLowerCase(peek) - 'a'));
                     }
                     else

--- a/src/Compilers/Lua/Portable/Parser/Lexer.cs
+++ b/src/Compilers/Lua/Portable/Parser/Lexer.cs
@@ -837,10 +837,6 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
             return false;
         }
 
-        public override void Dispose()
-        {
-            base.Dispose();
-            _cache.Free();
-        }
+        public void Dispose() => _cache.Free();
     }
 }

--- a/src/Compilers/Lua/Portable/Parser/Lexer.cs
+++ b/src/Compilers/Lua/Portable/Parser/Lexer.cs
@@ -143,9 +143,9 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                 switch (peek)
                 {
                     case '-':
-                        if (_reader.IsAt('-', 1))
+                        if (_reader.IsAt(1, '-'))
                         {
-                            _reader.Advance(2);
+                            _reader.Position += 2;
                             if (TryReadLongString(out _, out var closingNotFound))
                             {
                                 if (closingNotFound)
@@ -155,7 +155,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                             else
                             {
                                 while (_reader.Peek() is not (null or '\n' or '\r'))
-                                    _reader.Advance(1);
+                                    _reader.Position += 1;
                                 AddTrivia(SyntaxFactory.Comment(GetText(intern: false)), builder);
                             }
                         }
@@ -166,25 +166,25 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                         break;
 
                     case '/':
-                        if (_reader.IsAt('/', 1))
+                        if (_reader.IsAt(1, '/'))
                         {
-                            _reader.Advance(2);
+                            _reader.Position += 2;
                             while (_reader.Peek() is not (null or '\n' or '\r'))
-                                _reader.Advance(1);
+                                _reader.Position += 1;
 
                             if (!Options.SyntaxOptions.AcceptCCommentSyntax)
                                 AddError(ErrorCode.ERR_CCommentsNotSupportedInVersion);
                             AddTrivia(SyntaxFactory.Comment(GetText(intern: false)), builder);
                         }
-                        else if (_reader.IsAt('*', 1))
+                        else if (_reader.IsAt(1, '*'))
                         {
-                            _reader.Advance(2);
-                            _ = _reader.ReadSpanUntil("*/");
+                            _reader.Position += 2;
+                            _reader.SkipUntil("*/");
 
                             if (!_reader.IsNext("*/"))
                                 AddError(ErrorCode.ERR_UnfinishedLongComment);
                             else
-                                _reader.Advance(2);
+                                _reader.Position += 2;
 
                             if (!Options.SyntaxOptions.AcceptCCommentSyntax)
                                 AddError(ErrorCode.ERR_CCommentsNotSupportedInVersion);
@@ -197,10 +197,10 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                         break;
 
                     case '\r':
-                        _reader.Advance(1);
+                        _reader.Position += 1;
                         if (_reader.Peek() == '\n')
                         {
-                            _reader.Advance(1);
+                            _reader.Position += 1;
                             AddTrivia(SyntaxFactory.CarriageReturnLineFeed, builder);
                         }
                         else
@@ -212,10 +212,10 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                         break;
 
                     case '\n':
-                        _reader.Advance(1);
+                        _reader.Position += 1;
                         if (_reader.IsNext('\r'))
                         {
-                            _reader.Advance(1);
+                            _reader.Position += 1;
                             AddError(ErrorCode.WRN_LineBreakMayAffectErrorReporting);
                             AddTrivia(SyntaxFactory.EndOfLine("\n\r"), builder);
                         }
@@ -231,14 +231,14 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                     case '\t':
                     {
                         // Skip first char as we know it's whitespace.
-                        _reader.Advance(1);
+                        _reader.Position += 1;
 
                         char ch;
                         while ((ch = _reader.Peek().GetValueOrDefault()) != '\r'
                                 && ch != '\n'
                                 && char.IsWhiteSpace(ch))
                         {
-                            _reader.Advance(1);
+                            _reader.Position += 1;
                         }
 
                         var width = _reader.Position - _start;
@@ -260,10 +260,10 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                     }
 
                     case '#':
-                        if (_reader.Position == 0 && _reader.IsAt('!', 1))
+                        if (_reader.Position == 0 && _reader.IsAt(1, '!'))
                         {
-                            _reader.Advance(2);
-                            _ = _reader.ReadSpanLine();
+                            _reader.Position += 2;
+                            _reader.SkipUntilLineBreak();
 
                             if (!Options.SyntaxOptions.AcceptShebang)
                                 AddError(ErrorCode.ERR_ShebangNotSupportedInLuaVersion);
@@ -319,23 +319,23 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                     if (peek1 == '.')
                     {
                         // \.\.\.
-                        if (_reader.IsAt('.', 2))
+                        if (_reader.IsAt(2, '.'))
                         {
-                            _reader.Advance(3);
+                            _reader.Position += 3;
                             info.Kind = SyntaxKind.DotDotDotToken;
                             return;
                         }
                         // \.\.=
-                        else if (_reader.IsAt('=', 2))
+                        else if (_reader.IsAt(2, '='))
                         {
-                            _reader.Advance(3);
+                            _reader.Position += 3;
                             info.Kind = SyntaxKind.DotDotEqualsToken;
                             return;
                         }
                         // \.\.
                         else
                         {
-                            _reader.Advance(2);
+                            _reader.Position += 2;
                             info.Kind = SyntaxKind.DotDotToken;
                             return;
                         }
@@ -348,32 +348,32 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                     // \.
                     else
                     {
-                        _reader.Advance(1);
+                        _reader.Position += 1;
                         info.Kind = SyntaxKind.DotToken;
                         return;
                     }
                 }
 
                 case ';':
-                    _reader.Advance(1);
+                    _reader.Position += 1;
                     info.Kind = SyntaxKind.SemicolonToken;
                     return;
 
                 case ',':
-                    _reader.Advance(1);
+                    _reader.Position += 1;
                     info.Kind = SyntaxKind.CommaToken;
                     return;
 
                 case ':':
-                    if (_reader.IsAt(':', 1))
+                    if (_reader.IsAt(1, ':'))
                     {
-                        _reader.Advance(2);
+                        _reader.Position += 2;
                         info.Kind = SyntaxKind.ColonColonToken;
                         return;
                     }
                     else
                     {
-                        _reader.Advance(1);
+                        _reader.Position += 1;
                         info.Kind = SyntaxKind.ColonToken;
                         return;
                     }
@@ -381,12 +381,12 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                 #endregion Punctuation
 
                 case '(':
-                    _reader.Advance(1);
+                    _reader.Position += 1;
                     info.Kind = SyntaxKind.OpenParenthesisToken;
                     return;
 
                 case ')':
-                    _reader.Advance(1);
+                    _reader.Position += 1;
                     info.Kind = SyntaxKind.CloseParenthesisToken;
                     return;
 
@@ -403,142 +403,142 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                     }
                     else
                     {
-                        _reader.Advance(1);
+                        _reader.Position += 1;
                         info.Kind = SyntaxKind.OpenBracketToken;
                     }
                     return;
                 }
 
                 case ']':
-                    _reader.Advance(1);
+                    _reader.Position += 1;
                     info.Kind = SyntaxKind.CloseBracketToken;
                     return;
 
                 case '{':
-                    _reader.Advance(1);
+                    _reader.Position += 1;
                     info.Kind = SyntaxKind.OpenBraceToken;
                     return;
 
                 case '}':
-                    _reader.Advance(1);
+                    _reader.Position += 1;
                     info.Kind = SyntaxKind.CloseBraceToken;
                     return;
 
                 #region Operators
 
                 case '+':
-                    if (_reader.IsAt('=', 1))
+                    if (_reader.IsAt(1, '='))
                     {
-                        _reader.Advance(2);
+                        _reader.Position += 2;
                         info.Kind = SyntaxKind.PlusEqualsToken;
                         return;
                     }
                     else
                     {
-                        _reader.Advance(1);
+                        _reader.Position += 1;
                         info.Kind = SyntaxKind.PlusToken;
                         return;
                     }
 
                 case '-':
-                    if (_reader.IsAt('=', 1))
+                    if (_reader.IsAt(1, '='))
                     {
-                        _reader.Advance(2);
+                        _reader.Position += 2;
                         info.Kind = SyntaxKind.MinusEqualsToken;
                         return;
                     }
                     else
                     {
-                        _reader.Advance(1);
+                        _reader.Position += 1;
                         info.Kind = SyntaxKind.MinusToken;
                         return;
                     }
 
                 case '*':
-                    if (_reader.IsAt('=', 1))
+                    if (_reader.IsAt(1, '='))
                     {
-                        _reader.Advance(2);
+                        _reader.Position += 2;
                         info.Kind = SyntaxKind.StartEqualsToken;
                         return;
                     }
                     else
                     {
-                        _reader.Advance(1);
+                        _reader.Position += 1;
                         info.Kind = SyntaxKind.StarToken;
                         return;
                     }
 
                 case '/':
-                    if (_reader.IsAt('=', 1))
+                    if (_reader.IsAt(1, '='))
                     {
-                        _reader.Advance(2);
+                        _reader.Position += 2;
                         info.Kind = SyntaxKind.SlashEqualsToken;
                         return;
                     }
                     else
                     {
-                        _reader.Advance(1);
+                        _reader.Position += 1;
                         info.Kind = SyntaxKind.SlashToken;
                         return;
                     }
 
                 case '^':
-                    if (_reader.IsAt('=', 1))
+                    if (_reader.IsAt(1, '='))
                     {
-                        _reader.Advance(2);
+                        _reader.Position += 2;
                         info.Kind = SyntaxKind.HatEqualsToken;
                         return;
                     }
                     else
                     {
-                        _reader.Advance(1);
+                        _reader.Position += 1;
                         info.Kind = SyntaxKind.HatToken;
                         return;
                     }
 
                 case '%':
-                    if (_reader.IsAt('=', 1))
+                    if (_reader.IsAt(1, '='))
                     {
-                        _reader.Advance(2);
+                        _reader.Position += 2;
                         info.Kind = SyntaxKind.PercentEqualsToken;
                         return;
                     }
                     else
                     {
-                        _reader.Advance(1);
+                        _reader.Position += 1;
                         info.Kind = SyntaxKind.PercentToken;
                         return;
                     }
 
                 case '=':
-                    if (_reader.IsAt('=', 1))
+                    if (_reader.IsAt(1, '='))
                     {
-                        _reader.Advance(2);
+                        _reader.Position += 2;
                         info.Kind = SyntaxKind.EqualsEqualsToken;
                         return;
                     }
                     else
                     {
-                        _reader.Advance(1);
+                        _reader.Position += 1;
                         info.Kind = SyntaxKind.EqualsToken;
                         return;
                     }
 
                 case '#':
-                    _reader.Advance(1);
+                    _reader.Position += 1;
                     info.Kind = SyntaxKind.HashToken;
                     return;
 
                 case '~':
-                    if (_reader.IsAt('=', 1))
+                    if (_reader.IsAt(1, '='))
                     {
-                        _reader.Advance(2);
+                        _reader.Position += 2;
                         info.Kind = SyntaxKind.TildeEqualsToken;
                         return;
                     }
                     else
                     {
-                        _reader.Advance(1);
+                        _reader.Position += 1;
                         if (!Options.SyntaxOptions.AcceptBitwiseOperators)
                             AddError(ErrorCode.ERR_BitwiseOperatorsNotSupportedInVersion);
                         info.Kind = SyntaxKind.TildeToken;
@@ -549,19 +549,19 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                     switch (_reader.Peek(1))
                     {
                         case '=':
-                            _reader.Advance(2);
+                            _reader.Position += 2;
                             info.Kind = SyntaxKind.GreaterThanEqualsToken;
                             return;
 
                         case '>':
-                            _reader.Advance(2);
+                            _reader.Position += 2;
                             if (!Options.SyntaxOptions.AcceptBitwiseOperators)
                                 AddError(ErrorCode.ERR_BitwiseOperatorsNotSupportedInVersion);
                             info.Kind = SyntaxKind.GreaterThanGreaterThanToken;
                             return;
 
                         default:
-                            _reader.Advance(1);
+                            _reader.Position += 1;
                             info.Kind = SyntaxKind.GreaterThanToken;
                             return;
                     }
@@ -570,33 +570,33 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                     switch (_reader.Peek(1))
                     {
                         case '=':
-                            _reader.Advance(2);
+                            _reader.Position += 2;
                             info.Kind = SyntaxKind.LessThanEqualsToken;
                             return;
 
                         case '<':
-                            _reader.Advance(2);
+                            _reader.Position += 2;
                             if (!Options.SyntaxOptions.AcceptBitwiseOperators)
                                 AddError(ErrorCode.ERR_BitwiseOperatorsNotSupportedInVersion);
                             info.Kind = SyntaxKind.LessThanLessThanToken;
                             return;
 
                         default:
-                            _reader.Advance(1);
+                            _reader.Position += 1;
                             info.Kind = SyntaxKind.LessThanToken;
                             return;
                     }
 
                 case '&':
-                    if (_reader.IsAt('&', 1))
+                    if (_reader.IsAt(1, '&'))
                     {
-                        _reader.Advance(2);
+                        _reader.Position += 2;
                         info.Kind = SyntaxKind.AmpersandAmpersandToken;
                         return;
                     }
                     else
                     {
-                        _reader.Advance(1);
+                        _reader.Position += 1;
                         if (!Options.SyntaxOptions.AcceptBitwiseOperators)
                             AddError(ErrorCode.ERR_BitwiseOperatorsNotSupportedInVersion);
                         info.Kind = SyntaxKind.AmpersandToken;
@@ -604,15 +604,15 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                     }
 
                 case '|':
-                    if (_reader.IsAt('|', 1))
+                    if (_reader.IsAt(1, '|'))
                     {
-                        _reader.Advance(2);
+                        _reader.Position += 2;
                         info.Kind = SyntaxKind.PipePipeToken;
                         return;
                     }
                     else
                     {
-                        _reader.Advance(1);
+                        _reader.Position += 1;
                         if (!Options.SyntaxOptions.AcceptBitwiseOperators)
                             AddError(ErrorCode.ERR_BitwiseOperatorsNotSupportedInVersion);
                         info.Kind = SyntaxKind.PipeToken;
@@ -620,15 +620,15 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                     }
 
                 case '!':
-                    if (_reader.IsAt('=', 1))
+                    if (_reader.IsAt(1, '='))
                     {
-                        _reader.Advance(2);
+                        _reader.Position += 2;
                         info.Kind = SyntaxKind.BangEqualsToken;
                         return;
                     }
                     else
                     {
-                        _reader.Advance(1);
+                        _reader.Position += 1;
                         info.Kind = SyntaxKind.BangToken;
                         return;
                     }
@@ -646,7 +646,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                         case 'b':
                         case 'B':
                             // Skip the prefix
-                            _reader.Advance(2);
+                            _reader.Position += 2;
                             info.Kind = SyntaxKind.NumericLiteralToken;
                             info.DoubleValue = ParseBinaryNumber();
                             info.Text = GetText(intern: true);
@@ -656,7 +656,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                         case 'o':
                         case 'O':
                             // Skip the prefix
-                            _reader.Advance(2);
+                            _reader.Position += 2;
                             info.Kind = SyntaxKind.NumericLiteralToken;
                             info.DoubleValue = ParseOctalNumber();
                             info.Text = GetText(intern: true);
@@ -666,7 +666,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                         case 'x':
                         case 'X':
                             // Skip the prefix
-                            _reader.Advance(2);
+                            _reader.Position += 2;
                             info.Kind = SyntaxKind.NumericLiteralToken;
                             ParseHexadecimalNumber(ref info);
                             return;
@@ -758,9 +758,9 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                 case '_':
                 {
                     // We've already checked that the first letter is a valid identifier char. No need to re-check.
-                    _reader.Advance(1);
+                    _reader.Position += 1;
                     while (CharUtils.IsValidTrailingIdentifierChar(_reader.Peek().GetValueOrDefault()))
-                        _reader.Advance(1);
+                        _reader.Position += 1;
 
                     info.Text = info.StringValue = GetText(intern: true);
                     if (!_cache.TryGetKeywordKind(info.Text, out info.Kind))
@@ -794,7 +794,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                     }
                     else
                     {
-                        _reader.Advance(1);
+                        _reader.Position += 1;
                         info.Text = GetText(intern: true);
                     }
                     AddError(ErrorCode.ERR_BadCharacter, info.Text);
@@ -809,14 +809,14 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
             closingNotFound = true;
             var start = _reader.Position;
             if (_reader.IsNext('[')
-                 && (_reader.IsAt('=', 1)
-                      || _reader.IsAt('[', 1)))
+                 && (_reader.IsAt(1, '=')
+                      || _reader.IsAt(1, '[')))
             {
-                _reader.Advance(1);
+                _reader.Position += 1;
                 var equalSigns = _reader.ReadStringWhile(ch => ch == '=');
                 if (_reader.IsNext('['))
                 {
-                    _reader.Advance(1);
+                    _reader.Position += 1;
 
                     var closing = $"]{equalSigns}]";
                     contents = _reader.ReadStringUntil(closing);
@@ -824,19 +824,23 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                     if (_reader.IsNext(closing))
                     {
                         closingNotFound = false;
-                        _reader.Advance(closing.Length);
+                        _reader.Position += closing.Length;
                     }
 
                     return true;
                 }
 
-                _reader.Restore(start);
+                _reader.Position = start;
             }
 
             contents = null;
             return false;
         }
 
-        public void Dispose() => _cache.Free();
+        public override void Dispose()
+        {
+            base.Dispose();
+            _cache.Free();
+        }
     }
 }

--- a/src/Compilers/Lua/Portable/Parser/SourceTextReader.cs
+++ b/src/Compilers/Lua/Portable/Parser/SourceTextReader.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Buffers;
-using System.Diagnostics.CodeAnalysis;
-using Loretta.CodeAnalysis.PooledObjects;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {
@@ -155,7 +152,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                 return ReadToEnd();
 
             var length = idx - Position;
-            string value = _sourceText.ToString(new TextSpan(Position, length));
+            var value = _sourceText.ToString(new TextSpan(Position, length));
             Position = idx;
             return value;
         }
@@ -167,7 +164,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                 return ReadToEnd();
 
             var length = strEnd - Position;
-            string value = _sourceText.ToString(new TextSpan(Position, length));
+            var value = _sourceText.ToString(new TextSpan(Position, length));
             Position = strEnd;
             return value;
         }
@@ -175,7 +172,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
         public string ReadToEnd()
         {
             var length = Length - Position;
-            string value = _sourceText.ToString(new TextSpan(Position, length));
+            var value = _sourceText.ToString(new TextSpan(Position, length));
             Position = Length;
             return value;
         }

--- a/src/Compilers/Lua/Portable/Parser/SourceTextReader.cs
+++ b/src/Compilers/Lua/Portable/Parser/SourceTextReader.cs
@@ -1,0 +1,315 @@
+﻿using System;
+using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
+using Loretta.CodeAnalysis.PooledObjects;
+using Loretta.CodeAnalysis.Text;
+using Loretta.Utilities;
+
+namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
+{
+    internal class SourceTextReader : IDisposable
+    {
+        // We hold the next 2048 characters in the cache.
+        private const int CacheSize = 4096;
+        // And we require at least 128 characters available at all times
+        // except in the last 2048 characters of the text.
+        private const int CacheThreshold = 128;
+        private const int CacheSizeWithoutThreshold = CacheSize - CacheThreshold;
+        private static ObjectPool<char[]> s_cachePool = new ObjectPool<char[]>(() => new char[CacheSize], 128);
+
+        private readonly SourceText _sourceText;
+        private readonly char[] _cache;
+        private readonly int _maxCacheStart;
+        private int _position = 0;
+        private int _cacheStart = -1, _cachePosition = 0, _cacheLength = 0;
+
+        public SourceTextReader(SourceText sourceText)
+        {
+            _sourceText = sourceText;
+            _maxCacheStart = sourceText.Length - CacheSize;
+            _cache = s_cachePool.Allocate();
+            LoadCache(Position = 0);
+        }
+
+        public void Dispose()
+        {
+            s_cachePool.Free(_cache);
+        }
+
+        private void LoadCache(int cacheStart)
+        {
+            // Don't load the cache if the position hasn't changed.
+            if (_cacheStart == cacheStart)
+                return;
+            _cacheStart = cacheStart;
+            _cacheLength = Math.Min(Length - cacheStart, CacheSize);
+            Array.Clear(_cache, 0, CacheSize);
+            _sourceText.CopyTo(cacheStart, _cache, 0, _cacheLength);
+        }
+
+        /// <summary>
+        /// The reader's position. Guarantees the position is in the range [0, Length].
+        /// </summary>
+        public int Position
+        {
+            get => _position;
+            set
+            {
+                if (_position == value)
+                    return;
+
+                _position = Math.Min(Math.Max(value, 0), Length);
+
+                // If we moved behind the cache start
+                if (_position < _cacheStart
+                    // Or after the cache's threshold and not at the last N characters of the text
+                    || _cacheStart + CacheSizeWithoutThreshold <= _position)
+                {
+                    // Then load the cache with more characters
+                    LoadCache(Math.Min(_position, _maxCacheStart));
+                }
+
+                _cachePosition = _position - _cacheStart;
+            }
+        }
+
+        /// <summary>
+        /// The length of the text
+        /// </summary>
+        public int Length => _sourceText.Length;
+
+        private ReadOnlySpan<char> CacheSpan => _cache.AsSpan(_cachePosition, _cacheLength - _cachePosition);
+
+        public char? Peek() => Position < Length ? CacheSpan[0] : null;
+
+        public char? Peek(int offset)
+        {
+            if (offset < _cacheLength - _cachePosition)
+                return CacheSpan[offset];
+            var position = Position + offset;
+            if (position < Length)
+                return _sourceText[position];
+            return null;
+        }
+
+        public char? Read()
+        {
+            var ch = Peek();
+            Position++;
+            return ch;
+        }
+
+        public bool IsNext(char ch) => Peek() == ch;
+
+        public bool IsNext(string str)
+        {
+            var end = Position + str.Length;
+            if (end <= _cacheStart + _cacheLength)
+                return CacheSpan.StartsWith(str.AsSpan(), StringComparison.Ordinal);
+
+            if (end <= Length)
+            {
+                return slowIsNext(str);
+            }
+            return false;
+
+            bool slowIsNext(string str)
+            {
+                if (str.Length <= CacheSize)
+                {
+                    var buff = s_cachePool.Allocate();
+                    try
+                    {
+                        _sourceText.CopyTo(Position, buff, 0, str.Length);
+                        var span = buff.AsSpan(0, str.Length);
+                        return MemoryExtensions.Equals(span, str.AsSpan(), StringComparison.Ordinal);
+                    }
+                    finally
+                    {
+                        s_cachePool.Free(buff);
+                    }
+                }
+                else
+                {
+                    var buff = ArrayPool<char>.Shared.Rent(str.Length);
+                    try
+                    {
+                        _sourceText.CopyTo(Position, buff, 0, buff.Length);
+                        return MemoryExtensions.Equals(buff, str.AsSpan(), StringComparison.Ordinal);
+                    }
+                    finally
+                    {
+                        ArrayPool<char>.Shared.Return(buff);
+                    };
+                }
+            }
+        }
+
+        public bool IsAt(int offset, char ch) => Peek(offset) == ch;
+
+        public void SkipUntilLineBreak()
+        {
+            // Use the optimized and vectorized impl for the cache
+            var offset = CacheSpan.IndexOfAny('\n', '\r');
+            if (offset > 0)
+                Position += offset;
+
+            // Then if we don't find it in the cache, do the slow approach.
+            slowSkipUntilLineBreak();
+
+            void slowSkipUntilLineBreak()
+            {
+                var buff = s_cachePool.Allocate();
+                try
+                {
+                    for (int idx = _cacheStart + CacheSize + 1, length = CacheSize; idx < Length; length = Math.Min(Length - idx, CacheSize), idx += length)
+                    {
+                        _sourceText.CopyTo(idx, buff, 0, length);
+                        var offset = MemoryExtensions.IndexOfAny(buff.AsSpan(0, length), '\n', '\r');
+                        if (offset >= 0)
+                        {
+                            Position = idx + offset;
+                            return;
+                        }
+                    }
+                }
+                finally
+                {
+                    s_cachePool.Free(buff);
+                }
+            }
+        }
+
+        public bool TryGetInternedText(
+            StringTable strings,
+            int start,
+            int length,
+            [NotNullWhen(true)] out string? str)
+        {
+            var startInCache = start - _cacheStart;
+            if (_cacheStart <= start && length <= _cacheLength - startInCache)
+            {
+                str = strings.Add(_cache, startInCache, length);
+                return true;
+            }
+
+            str = default;
+            return false;
+        }
+
+        public int IndexOf(string value)
+        {
+            // Use the optimized and vectorized impl for the cache
+            var idx = CacheSpan.IndexOf(value.AsSpan(), StringComparison.Ordinal);
+            if (idx > 0)
+                return Position + idx;
+            // Then if we don't find it in the cache, do the slow approach.
+            return slowIndexOf(value);
+
+            bool isAt(int pos, string val)
+            {
+                switch (val.Length)
+                {
+                    case 1: return _sourceText[pos] == val[0];
+                    case 2: return _sourceText[pos] == val[0] && _sourceText[pos + 1] == val[1];
+                    case 3: return _sourceText[pos] == val[0] && _sourceText[pos + 1] == val[1] && _sourceText[pos + 2] == val[2];
+                    default:
+                        for (var idx = 0; idx < val.Length; idx++)
+                        {
+                            if (_sourceText[pos + idx] != val[idx])
+                                return false;
+                        }
+                        return true;
+                }
+            }
+
+            int slowIndexOf(string value)
+            {
+                for (var idx = _cacheStart + CacheSize + 1; idx < Length - value.Length; idx++)
+                {
+                    if (isAt(idx, value))
+                    {
+                        // The index starts with the stop, so skip until before it.
+                        return idx;
+                    }
+                }
+                return -1;
+            }
+        }
+
+        public int IndexOfFirstNotMatching(Func<char, bool> predicate)
+        {
+            for (var idx = 0; idx < _cacheLength - _cachePosition; idx++)
+            {
+                if (!predicate(CacheSpan[idx]))
+                    return Position + idx;
+            }
+            for (var idx = _cacheStart + CacheSize; idx < Length; idx++)
+            {
+                if (!predicate(_sourceText[idx]))
+                    return idx;
+            }
+            return -1;
+        }
+
+        public void SkipUntil(string stop)
+        {
+            var idx = IndexOf(stop);
+            if (idx < 0)
+                Position = Length;
+            Position = idx;
+        }
+
+        public void SkipWhile(Func<char, bool> predicate)
+        {
+            var idx = IndexOfFirstNotMatching(predicate);
+            if (idx < 0)
+                Position = Length;
+            Position = idx;
+        }
+
+        public string ReadStringUntil(string stop)
+        {
+            var idx = IndexOf(stop);
+            if (idx < 0)
+                return ReadToEnd();
+
+            string value;
+            var length = idx - Position;
+            if (length < _cacheLength - _cachePosition)
+                value = CacheSpan.Slice(0, length).ToString();
+            else
+                value = _sourceText.ToString(new TextSpan(Position, length));
+            Position = idx;
+            return value;
+        }
+
+        public string ReadStringWhile(Func<char, bool> predicate)
+        {
+            var strEnd = IndexOfFirstNotMatching(predicate);
+            if (strEnd < 0)
+                return ReadToEnd();
+
+            string value;
+            var length = strEnd - Position;
+            if (strEnd < _cacheStart + _cacheLength)
+                value = CacheSpan.Slice(0, length).ToString();
+            else
+                value = _sourceText.ToString(new TextSpan(Position, length));
+            Position = strEnd;
+            return value;
+        }
+
+        public string ReadToEnd()
+        {
+            var length = Length - Position;
+            string value;
+            if (_cacheStart == _maxCacheStart)
+                value = CacheSpan.Slice(0, length).ToString();
+            else
+                value = _sourceText.ToString(new TextSpan(Position, length));
+            Position = Length;
+            return value;
+        }
+    }
+}

--- a/src/Compilers/Lua/Portable/Parser/SourceTextReader.cs
+++ b/src/Compilers/Lua/Portable/Parser/SourceTextReader.cs
@@ -9,42 +9,16 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {
     internal class SourceTextReader : IDisposable
     {
-        // We hold the next 2048 characters in the cache.
-        private const int CacheSize = 4096;
-        // And we require at least 128 characters available at all times
-        // except in the last 2048 characters of the text.
-        private const int CacheThreshold = 128;
-        private const int CacheSizeWithoutThreshold = CacheSize - CacheThreshold;
-        private static ObjectPool<char[]> s_cachePool = new ObjectPool<char[]>(() => new char[CacheSize], 128);
-
         private readonly SourceText _sourceText;
-        private readonly char[] _cache;
-        private readonly int _maxCacheStart;
         private int _position = 0;
-        private int _cacheStart = -1, _cachePosition = 0, _cacheLength = 0;
 
         public SourceTextReader(SourceText sourceText)
         {
             _sourceText = sourceText;
-            _maxCacheStart = sourceText.Length - CacheSize;
-            _cache = s_cachePool.Allocate();
-            LoadCache(Position = 0);
         }
 
         public void Dispose()
         {
-            s_cachePool.Free(_cache);
-        }
-
-        private void LoadCache(int cacheStart)
-        {
-            // Don't load the cache if the position hasn't changed.
-            if (_cacheStart == cacheStart)
-                return;
-            _cacheStart = cacheStart;
-            _cacheLength = Math.Min(Length - cacheStart, CacheSize);
-            Array.Clear(_cache, 0, CacheSize);
-            _sourceText.CopyTo(cacheStart, _cache, 0, _cacheLength);
         }
 
         /// <summary>
@@ -59,17 +33,6 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                     return;
 
                 _position = Math.Min(Math.Max(value, 0), Length);
-
-                // If we moved behind the cache start
-                if (_position < _cacheStart
-                    // Or after the cache's threshold and not at the last N characters of the text
-                    || _cacheStart + CacheSizeWithoutThreshold <= _position)
-                {
-                    // Then load the cache with more characters
-                    LoadCache(Math.Min(_position, _maxCacheStart));
-                }
-
-                _cachePosition = _position - _cacheStart;
             }
         }
 
@@ -78,14 +41,10 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
         /// </summary>
         public int Length => _sourceText.Length;
 
-        private ReadOnlySpan<char> CacheSpan => _cache.AsSpan(_cachePosition, _cacheLength - _cachePosition);
-
-        public char? Peek() => Position < Length ? CacheSpan[0] : null;
+        public char? Peek() => Position < Length ? _sourceText[Position] : null;
 
         public char? Peek(int offset)
         {
-            if (offset < _cacheLength - _cachePosition)
-                return CacheSpan[offset];
             var position = Position + offset;
             if (position < Length)
                 return _sourceText[position];
@@ -103,108 +62,49 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 
         public bool IsNext(string str)
         {
-            var end = Position + str.Length;
-            if (end <= _cacheStart + _cacheLength)
-                return CacheSpan.StartsWith(str.AsSpan(), StringComparison.Ordinal);
+            if (Position + str.Length > Length)
+                return false;
 
-            if (end <= Length)
+            var buff = ArrayPool<char>.Shared.Rent(str.Length);
+            try
             {
-                return slowIsNext(str);
+                _sourceText.CopyTo(Position, buff, 0, str.Length);
+                return MemoryExtensions.Equals(buff.AsSpan(0, str.Length), str.AsSpan(), StringComparison.Ordinal);
             }
-            return false;
-
-            bool slowIsNext(string str)
+            finally
             {
-                if (str.Length <= CacheSize)
-                {
-                    var buff = s_cachePool.Allocate();
-                    try
-                    {
-                        _sourceText.CopyTo(Position, buff, 0, str.Length);
-                        var span = buff.AsSpan(0, str.Length);
-                        return MemoryExtensions.Equals(span, str.AsSpan(), StringComparison.Ordinal);
-                    }
-                    finally
-                    {
-                        s_cachePool.Free(buff);
-                    }
-                }
-                else
-                {
-                    var buff = ArrayPool<char>.Shared.Rent(str.Length);
-                    try
-                    {
-                        _sourceText.CopyTo(Position, buff, 0, buff.Length);
-                        return MemoryExtensions.Equals(buff, str.AsSpan(), StringComparison.Ordinal);
-                    }
-                    finally
-                    {
-                        ArrayPool<char>.Shared.Return(buff);
-                    };
-                }
-            }
+                ArrayPool<char>.Shared.Return(buff);
+            };
         }
 
         public bool IsAt(int offset, char ch) => Peek(offset) == ch;
 
         public void SkipUntilLineBreak()
         {
-            // Use the optimized and vectorized impl for the cache
-            var offset = CacheSpan.IndexOfAny('\n', '\r');
-            if (offset > 0)
-                Position += offset;
-
-            // Then if we don't find it in the cache, do the slow approach.
-            slowSkipUntilLineBreak();
-
-            void slowSkipUntilLineBreak()
+            for (var idx = Position; idx < Length; idx++)
             {
-                var buff = s_cachePool.Allocate();
-                try
+                if (_sourceText[idx] is '\n' or '\r')
                 {
-                    for (int idx = _cacheStart + CacheSize + 1, length = CacheSize; idx < Length; length = Math.Min(Length - idx, CacheSize), idx += length)
-                    {
-                        _sourceText.CopyTo(idx, buff, 0, length);
-                        var offset = MemoryExtensions.IndexOfAny(buff.AsSpan(0, length), '\n', '\r');
-                        if (offset >= 0)
-                        {
-                            Position = idx + offset;
-                            return;
-                        }
-                    }
-                }
-                finally
-                {
-                    s_cachePool.Free(buff);
+                    Position = idx;
+                    return;
                 }
             }
-        }
 
-        public bool TryGetInternedText(
-            StringTable strings,
-            int start,
-            int length,
-            [NotNullWhen(true)] out string? str)
-        {
-            var startInCache = start - _cacheStart;
-            if (_cacheStart <= start && length <= _cacheLength - startInCache)
-            {
-                str = strings.Add(_cache, startInCache, length);
-                return true;
-            }
-
-            str = default;
-            return false;
+            Position = Length;
+            return;
         }
 
         public int IndexOf(string value)
         {
-            // Use the optimized and vectorized impl for the cache
-            var idx = CacheSpan.IndexOf(value.AsSpan(), StringComparison.Ordinal);
-            if (idx > 0)
-                return Position + idx;
-            // Then if we don't find it in the cache, do the slow approach.
-            return slowIndexOf(value);
+            for (var idx = Position; idx <= Length - value.Length; idx++)
+            {
+                if (isAt(idx, value))
+                {
+                    // The index starts with the stop, so skip until before it.
+                    return idx;
+                }
+            }
+            return -1;
 
             bool isAt(int pos, string val)
             {
@@ -222,29 +122,11 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                         return true;
                 }
             }
-
-            int slowIndexOf(string value)
-            {
-                for (var idx = _cacheStart + CacheSize + 1; idx < Length - value.Length; idx++)
-                {
-                    if (isAt(idx, value))
-                    {
-                        // The index starts with the stop, so skip until before it.
-                        return idx;
-                    }
-                }
-                return -1;
-            }
         }
 
         public int IndexOfFirstNotMatching(Func<char, bool> predicate)
         {
-            for (var idx = 0; idx < _cacheLength - _cachePosition; idx++)
-            {
-                if (!predicate(CacheSpan[idx]))
-                    return Position + idx;
-            }
-            for (var idx = _cacheStart + CacheSize; idx < Length; idx++)
+            for (var idx = Position; idx < Length; idx++)
             {
                 if (!predicate(_sourceText[idx]))
                     return idx;
@@ -257,7 +139,8 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
             var idx = IndexOf(stop);
             if (idx < 0)
                 Position = Length;
-            Position = idx;
+            else
+                Position = idx;
         }
 
         public void SkipWhile(Func<char, bool> predicate)
@@ -265,7 +148,8 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
             var idx = IndexOfFirstNotMatching(predicate);
             if (idx < 0)
                 Position = Length;
-            Position = idx;
+            else
+                Position = idx;
         }
 
         public string ReadStringUntil(string stop)
@@ -274,12 +158,8 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
             if (idx < 0)
                 return ReadToEnd();
 
-            string value;
             var length = idx - Position;
-            if (length < _cacheLength - _cachePosition)
-                value = CacheSpan.Slice(0, length).ToString();
-            else
-                value = _sourceText.ToString(new TextSpan(Position, length));
+            string value = _sourceText.ToString(new TextSpan(Position, length));
             Position = idx;
             return value;
         }
@@ -290,12 +170,8 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
             if (strEnd < 0)
                 return ReadToEnd();
 
-            string value;
             var length = strEnd - Position;
-            if (strEnd < _cacheStart + _cacheLength)
-                value = CacheSpan.Slice(0, length).ToString();
-            else
-                value = _sourceText.ToString(new TextSpan(Position, length));
+            string value = _sourceText.ToString(new TextSpan(Position, length));
             Position = strEnd;
             return value;
         }
@@ -303,11 +179,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
         public string ReadToEnd()
         {
             var length = Length - Position;
-            string value;
-            if (_cacheStart == _maxCacheStart)
-                value = CacheSpan.Slice(0, length).ToString();
-            else
-                value = _sourceText.ToString(new TextSpan(Position, length));
+            string value = _sourceText.ToString(new TextSpan(Position, length));
             Position = Length;
             return value;
         }

--- a/src/Compilers/Lua/Portable/Parser/SourceTextReader.cs
+++ b/src/Compilers/Lua/Portable/Parser/SourceTextReader.cs
@@ -7,7 +7,7 @@ using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {
-    internal class SourceTextReader : IDisposable
+    internal class SourceTextReader
     {
         private readonly SourceText _sourceText;
         private int _position = 0;
@@ -15,10 +15,6 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
         public SourceTextReader(SourceText sourceText)
         {
             _sourceText = sourceText;
-        }
-
-        public void Dispose()
-        {
         }
 
         /// <summary>

--- a/src/Tools/LuaStatisticsCollector/Program.cs
+++ b/src/Tools/LuaStatisticsCollector/Program.cs
@@ -86,8 +86,8 @@ namespace Loretta.CodeAnalysis.Lua.StatisticsCollector
                 .WithDegreeOfParallelism(Environment.ProcessorCount * 2)
                 .Select(file =>
                 {
-                    using var reader = file.OpenText();
-                    return new SourceFile(file.Name, SourceText.From(reader.ReadToEnd(), Encoding.UTF8));
+                    using var stream = file.OpenRead();
+                    return new SourceFile(file.Name, SourceText.From(stream, Encoding.UTF8));
                 })
                 .ToImmutableArray();
             s_totalFiles = files.Length;


### PR DESCRIPTION
By implementing the SourceTextReader, we get rid of `ICodeReader` (and consequently) GParse as well as avoid Large Object Heap allocations from calling `ToString()` on the `SourceText`s in the `Lexer`.