### PR TITLE
Add the whitespace escape flag

### DIFF
--- a/Loretta.sln
+++ b/Loretta.sln
@@ -4,6 +4,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 16.6.30114.105
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{C487233C-597B-4FF3-8061-1B321E556E74}"
+	ProjectSection(SolutionItems) = preProject
+		src\Directory.Build.props = src\Directory.Build.props
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Compilers", "Compilers", "{9715D006-5CE6-4387-94B3-C12C53E179CF}"
 EndProject

--- a/src/Compilers/Lua/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/Lua/Portable/Errors/ErrorCode.cs
@@ -28,6 +28,7 @@
         ERR_DoubleOverflow = 20,
         ERR_BitwiseOperatorsNotSupportedInVersion = 21,
         WRN_LineBreakMayAffectErrorReporting = 22,
+        ERR_WhitespaceEscapeNotSupportedInVersion = 23,
 
         // Parser Errors
         ERR_IdentifierExpectedKW = 1000,

--- a/src/Compilers/Lua/Portable/LuaResources.Designer.cs
+++ b/src/Compilers/Lua/Portable/LuaResources.Designer.cs
@@ -331,6 +331,15 @@ namespace Loretta.CodeAnalysis.Lua {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The whitespace escape (&apos;\z&apos;) is not supported in this lua version..
+        /// </summary>
+        internal static string ERR_WhitespaceEscapeNotSupportedInVersion {
+            get {
+                return ResourceManager.GetString("ERR_WhitespaceEscapeNotSupportedInVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This method can only be used to create tokens - {0} is not a token kind..
         /// </summary>
         internal static string ThisMethodCanOnlyBeUsedToCreateTokens {

--- a/src/Compilers/Lua/Portable/LuaResources.resx
+++ b/src/Compilers/Lua/Portable/LuaResources.resx
@@ -211,6 +211,9 @@
   <data name="ERR_UnfinishedString" xml:space="preserve">
     <value>Unfinished string</value>
   </data>
+  <data name="ERR_WhitespaceEscapeNotSupportedInVersion" xml:space="preserve">
+    <value>The whitespace escape ('\z') is not supported in this lua version.</value>
+  </data>
   <data name="ThisMethodCanOnlyBeUsedToCreateTokens" xml:space="preserve">
     <value>This method can only be used to create tokens - {0} is not a token kind.</value>
     <comment>{0} is the token kind</comment>

--- a/src/Compilers/Lua/Portable/LuaSyntaxOptions.cs
+++ b/src/Compilers/Lua/Portable/LuaSyntaxOptions.cs
@@ -30,6 +30,7 @@ namespace Loretta.CodeAnalysis.Lua
             acceptUnderscoreInNumberLiterals: false,
             useLuaJitIdentifierRules: false,
             acceptBitwiseOperators: false,
+            acceptWhitespaceEscape: false,
             continueType: ContinueType.None);
 
         /// <summary>
@@ -39,7 +40,14 @@ namespace Loretta.CodeAnalysis.Lua
             acceptEmptyStatements: true,
             acceptGoto: true,
             acceptHexEscapesInStrings: true,
-            acceptHexFloatLiterals: true);
+            acceptHexFloatLiterals: true,
+            acceptWhitespaceEscape: true);
+
+        /// <summary>
+        /// The Lua 5.3 preset.
+        /// </summary>
+        public static readonly LuaSyntaxOptions Lua53 = Lua52.With(
+            acceptBitwiseOperators: true);
 
         /// <summary>
         /// The LuaJIT preset.
@@ -58,6 +66,7 @@ namespace Loretta.CodeAnalysis.Lua
             acceptUnderscoreInNumberLiterals: false,
             useLuaJitIdentifierRules: true,
             acceptBitwiseOperators: false,
+            acceptWhitespaceEscape: false,
             continueType: ContinueType.None);
 
         /// <summary>
@@ -85,6 +94,7 @@ namespace Loretta.CodeAnalysis.Lua
             acceptUnderscoreInNumberLiterals: true,
             useLuaJitIdentifierRules: false,
             acceptBitwiseOperators: true,
+            acceptWhitespaceEscape: true,
             continueType: ContinueType.ContextualKeyword);
 
         /// <summary>
@@ -105,6 +115,7 @@ namespace Loretta.CodeAnalysis.Lua
             acceptUnderscoreInNumberLiterals: true,
             useLuaJitIdentifierRules: true,
             acceptBitwiseOperators: true,
+            acceptWhitespaceEscape: true,
             continueType: ContinueType.ContextualKeyword);
 
         /// <summary>
@@ -136,6 +147,7 @@ namespace Loretta.CodeAnalysis.Lua
         /// <param name="acceptUnderscoreInNumberLiterals"><inheritdoc cref="AcceptUnderscoreInNumberLiterals" path="/summary" /></param>
         /// <param name="useLuaJitIdentifierRules"><inheritdoc cref="UseLuaJitIdentifierRules" path="/summary" /></param>
         /// <param name="acceptBitwiseOperators"><inheritdoc cref="AcceptBitwiseOperators" path="/summary"/></param>
+        /// <param name="acceptWhitespaceEscape"><inheritdoc cref="AcceptWhitespaceEscape" path="/summary"/></param>
         /// <param name="continueType"><inheritdoc cref="ContinueType" path="/summary" /></param>
         public LuaSyntaxOptions(
             bool acceptBinaryNumbers,
@@ -151,6 +163,7 @@ namespace Loretta.CodeAnalysis.Lua
             bool acceptUnderscoreInNumberLiterals,
             bool useLuaJitIdentifierRules,
             bool acceptBitwiseOperators,
+            bool acceptWhitespaceEscape,
             ContinueType continueType)
         {
             AcceptBinaryNumbers = acceptBinaryNumbers;
@@ -166,6 +179,7 @@ namespace Loretta.CodeAnalysis.Lua
             AcceptUnderscoreInNumberLiterals = acceptUnderscoreInNumberLiterals;
             UseLuaJitIdentifierRules = useLuaJitIdentifierRules;
             AcceptBitwiseOperators = acceptBitwiseOperators;
+            AcceptWhitespaceEscape = acceptWhitespaceEscape;
             ContinueType = continueType;
         }
 
@@ -243,6 +257,11 @@ namespace Loretta.CodeAnalysis.Lua
         public bool AcceptBitwiseOperators { get; }
 
         /// <summary>
+        /// Whether to <b>not</b> error when encountering <c>\z</c> escapes.
+        /// </summary>
+        public bool AcceptWhitespaceEscape { get; }
+
+        /// <summary>
         /// The type of continue to be recognized by the parser.
         /// </summary>
         public ContinueType ContinueType { get; }
@@ -302,6 +321,10 @@ namespace Loretta.CodeAnalysis.Lua
         /// <inheritdoc cref="AcceptBitwiseOperators" path="/summary"/> If None uses the value of
         /// <see cref="AcceptBitwiseOperators"/>.
         /// </param>
+        /// <param name="acceptWhitespaceEscape">
+        /// <inheritdoc cref="AcceptWhitespaceEscape" path="/summary"/> If None uses the value of
+        /// <see cref="AcceptWhitespaceEscape"/>.
+        /// </param>
         /// <param name="continueType">
         /// <inheritdoc cref="ContinueType" path="/summary" /> If None uses the value of <see
         /// cref="ContinueType" />.
@@ -321,6 +344,7 @@ namespace Loretta.CodeAnalysis.Lua
             Option<bool> acceptUnderscoreInNumberLiterals = default,
             Option<bool> useLuaJitIdentifierRules = default,
             Option<bool> acceptBitwiseOperators = default,
+            Option<bool> acceptWhitespaceEscape = default,
             Option<ContinueType> continueType = default) =>
             new LuaSyntaxOptions(
                 acceptBinaryNumbers.UnwrapOr(AcceptBinaryNumbers),
@@ -336,6 +360,7 @@ namespace Loretta.CodeAnalysis.Lua
                 acceptUnderscoreInNumberLiterals.UnwrapOr(AcceptUnderscoreInNumberLiterals),
                 useLuaJitIdentifierRules.UnwrapOr(UseLuaJitIdentifierRules),
                 acceptBitwiseOperators.UnwrapOr(AcceptBitwiseOperators),
+                acceptWhitespaceEscape.UnwrapOr(AcceptWhitespaceEscape),
                 continueType.UnwrapOr(ContinueType));
 
         /// <inheritdoc/>
@@ -359,6 +384,7 @@ namespace Loretta.CodeAnalysis.Lua
                 && AcceptUnderscoreInNumberLiterals == other.AcceptUnderscoreInNumberLiterals
                 && UseLuaJitIdentifierRules == other.UseLuaJitIdentifierRules
                 && AcceptBitwiseOperators == other.AcceptBitwiseOperators
+                && AcceptWhitespaceEscape == other.AcceptWhitespaceEscape
                 && ContinueType == other.ContinueType);
 
         /// <inheritdoc/>
@@ -378,6 +404,7 @@ namespace Loretta.CodeAnalysis.Lua
             hash.Add(AcceptUnderscoreInNumberLiterals);
             hash.Add(UseLuaJitIdentifierRules);
             hash.Add(AcceptBitwiseOperators);
+            hash.Add(AcceptWhitespaceEscape);
             hash.Add(ContinueType);
             return hash.ToHashCode();
         }
@@ -392,6 +419,10 @@ namespace Loretta.CodeAnalysis.Lua
             else if (this == Lua52)
             {
                 return "Lua 5.2";
+            }
+            else if (this == Lua53)
+            {
+                return "Lua 5.3";
             }
             else if (this == LuaJIT)
             {
@@ -411,7 +442,7 @@ namespace Loretta.CodeAnalysis.Lua
             }
             else
             {
-                return $"{{ AcceptBinaryNumbers = {AcceptBinaryNumbers}, AcceptCCommentSyntax = {AcceptCCommentSyntax}, AcceptCompoundAssignment = {AcceptCompoundAssignment}, AcceptEmptyStatements = {AcceptEmptyStatements}, AcceptCBooleanOperators = {AcceptCBooleanOperators}, AcceptGoto = {AcceptGoto}, AcceptHexEscapesInStrings = {AcceptHexEscapesInStrings}, AcceptHexFloatLiterals = {AcceptHexFloatLiterals}, AcceptOctalNumbers = {AcceptOctalNumbers}, AcceptShebang = {AcceptShebang}, AcceptUnderscoreInNumberLiterals = {AcceptUnderscoreInNumberLiterals}, UseLuaJitIdentifierRules = {UseLuaJitIdentifierRules}, AcceptBitwiseOperators = {AcceptBitwiseOperators}, ContinueType = {ContinueType} }}";
+                return $"{{ AcceptBinaryNumbers = {AcceptBinaryNumbers}, AcceptCCommentSyntax = {AcceptCCommentSyntax}, AcceptCompoundAssignment = {AcceptCompoundAssignment}, AcceptEmptyStatements = {AcceptEmptyStatements}, AcceptCBooleanOperators = {AcceptCBooleanOperators}, AcceptGoto = {AcceptGoto}, AcceptHexEscapesInStrings = {AcceptHexEscapesInStrings}, AcceptHexFloatLiterals = {AcceptHexFloatLiterals}, AcceptOctalNumbers = {AcceptOctalNumbers}, AcceptShebang = {AcceptShebang}, AcceptUnderscoreInNumberLiterals = {AcceptUnderscoreInNumberLiterals}, UseLuaJitIdentifierRules = {UseLuaJitIdentifierRules}, AcceptBitwiseOperators = {AcceptBitwiseOperators}, AcceptWhitespaceEscape = {AcceptWhitespaceEscape}, ContinueType = {ContinueType} }}";
             }
         }
 

--- a/src/Compilers/Lua/Portable/Parser/Lexer.ShortString.cs
+++ b/src/Compilers/Lua/Portable/Parser/Lexer.ShortString.cs
@@ -97,6 +97,9 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                             case 'z':
                                 _reader.Position += 1;
                                 _reader.SkipWhile(static c => CharUtils.IsWhitespace(c));
+
+                                if (!Options.SyntaxOptions.AcceptWhitespaceEscape)
+                                    AddError(escapeStart, _reader.Position - escapeStart, ErrorCode.ERR_WhitespaceEscapeNotSupportedInVersion);
                                 break;
 
                             case '0':

--- a/src/Compilers/Lua/Portable/Utilities/CharUtils.cs
+++ b/src/Compilers/Lua/Portable/Utilities/CharUtils.cs
@@ -38,7 +38,6 @@ namespace Loretta.CodeAnalysis.Lua.Utilities
         /// in the provided (sorted and flattened) list.
         /// </summary>
         /// <param name="idx">The index found by binary search.</param>
-        /// 
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool InnerIsInRangesIndexCheck(int idx) =>

--- a/src/Compilers/Lua/Test/Syntax/Lexical/LexicalErrorTests.cs
+++ b/src/Compilers/Lua/Test/Syntax/Lexical/LexicalErrorTests.cs
@@ -344,6 +344,7 @@ local str4 = 'hello\xFFthere'
         }
 
         [Fact]
+        [Trait("Category", "Lexer/Diagnostics")]
         public void Lexer_EmitsWarning_ForExoticLineBreak()
         {
             const string source = "local a = 1\n\rlocal b = 2\n\rlocal c = 3";
@@ -357,11 +358,13 @@ local str4 = 'hello\xFFthere'
         }
 
         [Fact]
+        [Trait("Category", "Lexer/Diagnostics")]
         public void Lexer_EmitsDiagnosticsWhen_WhitespaceEscapesAreFound_And_LuaSyntaxOptionsAcceptWhitespaceEscapeIsFalse()
         {
             const string source = "local a = \"aaa\\z    aaaa\"\r\n" +
                 "local b = 'aaa\\z    aaaa'";
-            ParseAndValidate(source, null,
+            var options = LuaSyntaxOptions.All.With(acceptWhitespaceEscape: false);
+            ParseAndValidate(source, options,
                 // (1,15): error LUA0023: The whitespace escape ('\z') is not supported in this lua version.
                 // local a = "aaa\z    aaaa"
                 Diagnostic(ErrorCode.ERR_WhitespaceEscapeNotSupportedInVersion, @"\z    ").WithLocation(1, 15),

--- a/src/Compilers/Lua/Test/Syntax/Lexical/LexicalErrorTests.cs
+++ b/src/Compilers/Lua/Test/Syntax/Lexical/LexicalErrorTests.cs
@@ -355,5 +355,19 @@ local str4 = 'hello\xFFthere'
                 // local b = 2
                 Diagnostic(ErrorCode.WRN_LineBreakMayAffectErrorReporting, "\n\r").WithLocation(3, 12));
         }
+
+        [Fact]
+        public void Lexer_EmitsDiagnosticsWhen_WhitespaceEscapesAreFound_And_LuaSyntaxOptionsAcceptWhitespaceEscapeIsFalse()
+        {
+            const string source = "local a = \"aaa\\z    aaaa\"\r\n" +
+                "local b = 'aaa\\z    aaaa'";
+            ParseAndValidate(source, null,
+                // (1,15): error LUA0023: The whitespace escape ('\z') is not supported in this lua version.
+                // local a = "aaa\z    aaaa"
+                Diagnostic(ErrorCode.ERR_WhitespaceEscapeNotSupportedInVersion, @"\z    ").WithLocation(1, 15),
+                // (2,15): error LUA0023: The whitespace escape ('\z') is not supported in this lua version.
+                // local b = 'aaa\z    aaaa'
+                Diagnostic(ErrorCode.ERR_WhitespaceEscapeNotSupportedInVersion, @"\z    ").WithLocation(2, 15));
+        }
     }
 }

--- a/src/Compilers/Lua/Test/Syntax/Lexical/LexicalTestData.cs
+++ b/src/Compilers/Lua/Test/Syntax/Lexical/LexicalTestData.cs
@@ -104,8 +104,10 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.UnitTests.Lexical
 
             #region Strings
 
-            const string shortStringContentText = "hi\\\n\\\r\\\r\n\\a\\b\\f\\n\\r\\t\\v\\\\\\'\\\"\\0\\10\\255\\xF\\xFF";
-            const string shortStringContentValue = "hi\n\r\r\n\a\b\f\n\r\t\v\\'\"\0\xA\xFF\xF\xFF";
+            const string shortStringContentText = "hi\\\n\\\r\\\r\n\\a\\b\\f\\n\\r\\t\\v\\\\\\'\\\"\\0\\10"
+                + "\\255\\xF\\xFF\\z    \t\t\r\n\\\\a";
+            const string shortStringContentValue = "hi\n\r\r\n\a\b\f\n\r\t\v\\'\"\0\xA"
+                + "\xFF\xF\xFF\\a";
 
             // Short strings
             foreach (var quote in new[] { '\'', '"' })


### PR DESCRIPTION
This implements the `\z` acceptance flag to `LuaSyntaxOptions`.