### PR TITLE
Fix some parser errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed errors not being reported for missing expressions.
+- Fixed an error not being reported when a compound assignment is parsed and `AcceptCompoundAssignment` is false.
 
 ### Changed
 - Changed the generated expression in the case of a missing expression (now it is a `IdentifierNameSyntax`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added support for Luau's if expression.
 
+### Fixed
+- Fixed errors not being reported for missing expressions.
+
+### Changed
+- Changed the generated expression in the case of a missing expression (now it is a `IdentifierNameSyntax`
+  with `IsMissing` set to `true`).
+- Changed the generated statement in the case of a missing expression (now it is an `ExpressionStatementSyntax`
+  with `IsMissing` set to `true` and the inner expression is the one in the bullet point above).
+- Changed the generated error message in the case of a missing/invalid statement.
+
 ## v0.2.7-beta.4
 ### Changed
 - Fixed a typo in `EmptyStatementSyntax` and its helper methods.

--- a/src/Compilers/Lua/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/Lua/Portable/Errors/ErrorCode.cs
@@ -50,6 +50,7 @@
         // Using part instead of term here because it's more user friendly.
         ERR_InvalidExpressionPart = 1011,
         ERR_InvalidStatement = 1012,
+        ERR_CompoundAssignmentNotSupportedInLuaVersion = 1013,
 
         // MessageProvider stuff
         ERR_BadDocumentationMode = 2000,

--- a/src/Compilers/Lua/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/Lua/Portable/Errors/ErrorCode.cs
@@ -46,6 +46,10 @@
         ERR_InsufficientStack = 1007,
         ERR_IfExpressionsNotSupportedInLuaVersion = 1008,
         ERR_IfExpressionConditionExpected = 1009,
+        ERR_ExpressionExpected = 1010,
+        // Using part instead of term here because it's more user friendly.
+        ERR_InvalidExpressionPart = 1011,
+        ERR_InvalidStatement = 1012,
 
         // MessageProvider stuff
         ERR_BadDocumentationMode = 2000,

--- a/src/Compilers/Lua/Portable/LuaResources.Designer.cs
+++ b/src/Compilers/Lua/Portable/LuaResources.Designer.cs
@@ -133,6 +133,15 @@ namespace Loretta.CodeAnalysis.Lua {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Compound assignments are not supported in this lua version.
+        /// </summary>
+        internal static string ERR_CompoundAssignmentNotSupportedInLuaVersion {
+            get {
+                return ResourceManager.GetString("ERR_CompoundAssignmentNotSupportedInLuaVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Constant represents a value either too large or too small for a double precision floating-point number.
         /// </summary>
         internal static string ERR_DoubleOverflow {

--- a/src/Compilers/Lua/Portable/LuaResources.Designer.cs
+++ b/src/Compilers/Lua/Portable/LuaResources.Designer.cs
@@ -151,6 +151,15 @@ namespace Loretta.CodeAnalysis.Lua {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Expression expected.
+        /// </summary>
+        internal static string ERR_ExpressionExpected {
+            get {
+                return ResourceManager.GetString("ERR_ExpressionExpected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Hexadecimal digit expected.
         /// </summary>
         internal static string ERR_HexDigitExpected {
@@ -241,11 +250,29 @@ namespace Loretta.CodeAnalysis.Lua {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid expression part &apos;{0}&apos;.
+        /// </summary>
+        internal static string ERR_InvalidExpressionPart {
+            get {
+                return ResourceManager.GetString("ERR_InvalidExpressionPart", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid number.
         /// </summary>
         internal static string ERR_InvalidNumber {
             get {
                 return ResourceManager.GetString("ERR_InvalidNumber", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid statement.
+        /// </summary>
+        internal static string ERR_InvalidStatement {
+            get {
+                return ResourceManager.GetString("ERR_InvalidStatement", resourceCulture);
             }
         }
         

--- a/src/Compilers/Lua/Portable/LuaResources.resx
+++ b/src/Compilers/Lua/Portable/LuaResources.resx
@@ -142,6 +142,9 @@
   <data name="ERR_CloseParenExpected" xml:space="preserve">
     <value>) expected</value>
   </data>
+  <data name="ERR_CompoundAssignmentNotSupportedInLuaVersion" xml:space="preserve">
+    <value>Compound assignments are not supported in this lua version</value>
+  </data>
   <data name="ERR_DoubleOverflow" xml:space="preserve">
     <value>Constant represents a value either too large or too small for a double precision floating-point number</value>
   </data>

--- a/src/Compilers/Lua/Portable/LuaResources.resx
+++ b/src/Compilers/Lua/Portable/LuaResources.resx
@@ -149,6 +149,9 @@
     <value>Escape is too large, the limit is {0}</value>
     <comment>{0} is the numerical limit</comment>
   </data>
+  <data name="ERR_ExpressionExpected" xml:space="preserve">
+    <value>Expression expected</value>
+  </data>
   <data name="ERR_HexDigitExpected" xml:space="preserve">
     <value>Hexadecimal digit expected</value>
   </data>
@@ -180,8 +183,15 @@
   <data name="ERR_InsufficientStack" xml:space="preserve">
     <value>An expression is too long or complex to compile</value>
   </data>
+  <data name="ERR_InvalidExpressionPart" xml:space="preserve">
+    <value>Invalid expression part '{0}'</value>
+    <comment>{0} is the text of the token found</comment>
+  </data>
   <data name="ERR_InvalidNumber" xml:space="preserve">
     <value>Invalid number</value>
+  </data>
+  <data name="ERR_InvalidStatement" xml:space="preserve">
+    <value>Invalid statement</value>
   </data>
   <data name="ERR_InvalidStringEscape" xml:space="preserve">
     <value>Invalid string escape</value>

--- a/src/Compilers/Lua/Portable/LuaSyntaxOptions.cs
+++ b/src/Compilers/Lua/Portable/LuaSyntaxOptions.cs
@@ -210,11 +210,6 @@ namespace Loretta.CodeAnalysis.Lua
         /// <summary>
         /// Whether to accept binary numbers (format: /0b[10]+/).
         /// </summary>
-        /// <remarks>
-        /// "accept" means an <see cref="DiagnosticSeverity.Error"/> <see cref="Diagnostic"/> will be
-        /// raised when encountering a binary number, however the parsing process will still continue
-        /// as if the number was a normal one.
-        /// </remarks>
         public bool AcceptBinaryNumbers { get; }
 
         /// <summary>
@@ -223,8 +218,8 @@ namespace Loretta.CodeAnalysis.Lua
         public bool AcceptCCommentSyntax { get; }
 
         /// <summary>
-        /// Whether to accept compound assignment syntax (format: &lt;expr&gt; ("+=" | "-=" | "*=" |
-        /// "/=" | "^=" | "%=" | "..=") &lt;expr&gt;).
+        /// Whether to accept compound assignment syntax
+        /// (format: &lt;expr&gt; ("+=" | "-=" | "*=" | "/=" | "^=" | "%=" | "..=") &lt;expr&gt;).
         /// </summary>
         public bool AcceptCompoundAssignment { get; }
 
@@ -234,7 +229,7 @@ namespace Loretta.CodeAnalysis.Lua
         public bool AcceptEmptyStatements { get; }
 
         /// <summary>
-        /// Whether to accept the C boolean operators (&amp;&amp;, ||, != and !).
+        /// Whether to accept C boolean operators (&amp;&amp;, ||, != and !).
         /// </summary>
         public bool AcceptCBooleanOperators { get; }
 
@@ -249,7 +244,8 @@ namespace Loretta.CodeAnalysis.Lua
         public bool AcceptHexEscapesInStrings { get; }
 
         /// <summary>
-        /// Whether to accept hexadecimal floating point literals (format: /0x[a-fA-F0-9]+(\.[a-fA-F0-9])?([+-]?p[0-9]+)/).
+        /// Whether to accept hexadecimal floating point literals
+        /// (format: /0x[a-fA-F0-9]+(\.[a-fA-F0-9])?([+-]?p[0-9]+)/).
         /// </summary>
         public bool AcceptHexFloatLiterals { get; }
 
@@ -259,7 +255,7 @@ namespace Loretta.CodeAnalysis.Lua
         public bool AcceptOctalNumbers { get; }
 
         /// <summary>
-        /// Whether to accept shebangs (format: "#!...") (currently accepted anywhere inside the file).
+        /// Whether to accept shebangs (format: "#!...").
         /// </summary>
         public bool AcceptShebang { get; }
 
@@ -275,17 +271,17 @@ namespace Loretta.CodeAnalysis.Lua
         public bool UseLuaJitIdentifierRules { get; }
 
         /// <summary>
-        /// Whether to error when encountering 5.3 bitise operators.
+        /// Whether to accept 5.3 bitise operators.
         /// </summary>
         public bool AcceptBitwiseOperators { get; }
 
         /// <summary>
-        /// Whether to <b>not</b> error when encountering <c>\z</c> escapes.
+        /// Whether to accept <c>\z</c> escapes.
         /// </summary>
         public bool AcceptWhitespaceEscape { get; }
 
         /// <summary>
-        /// Whether to <b>not</b> error when encountering Unicode (<c>\u{XXX}</c>) escapes.
+        /// Whether to accept Unicode (<c>\u{XXX}</c>) escapes.
         /// </summary>
         public bool AcceptUnicodeEscape { get; }
 
@@ -295,7 +291,7 @@ namespace Loretta.CodeAnalysis.Lua
         public ContinueType ContinueType { get; }
 
         /// <summary>
-        /// Whether to <b>not</b> error when encountering Luau if expressions.
+        /// Whether to accept Luau if expressions.
         /// </summary>
         public bool AcceptIfExpressions { get; }
 

--- a/src/Compilers/Lua/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/Lua/Portable/Parser/LanguageParser.cs
@@ -168,27 +168,40 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                         if (CurrentToken.ContextualKind == SyntaxKind.ContinueKeyword)
                             return ParseContinueStatement();
 
+                        var restorePoint = GetResetPoint();
                         var expression = ParsePrefixOrVariableExpression();
-                        if (expression.Kind is SyntaxKind.BadExpression)
+                        if (expression.IsMissing)
                         {
-                            var semicolon = TryMatchSemicolon();
-                            return SyntaxFactory.BadStatement((BadExpressionSyntax) expression, semicolon);
-                        }
-
-                        if (CurrentToken.Kind is SyntaxKind.CommaToken or SyntaxKind.EqualsToken)
-                        {
-                            return ParseAssignmentStatement(expression);
-                        }
-                        else if (SyntaxFacts.IsCompoundAssignmentOperatorToken(CurrentToken.Kind))
-                        {
-                            return ParseCompoundAssignment(expression);
+                            // If the expression is missing, reset and then consume the token we cannot process
+                            // generating a *minimal* missing statement so that we can continue.
+                            Reset(ref restorePoint);
+                            var token = EatToken();
+                            return AddError(
+                                SyntaxFactory.ExpressionStatement(
+                                    AddLeadingSkippedSyntax(
+                                        CreateMissingIdentifierName(),
+                                        token),
+                                    null),
+                                ErrorCode.ERR_InvalidStatement);
                         }
                         else
                         {
+                            if (CurrentToken.Kind is SyntaxKind.CommaToken or SyntaxKind.EqualsToken)
+                            {
+                                return ParseAssignmentStatement(expression);
+                            }
+                            else if (SyntaxFacts.IsCompoundAssignmentOperatorToken(CurrentToken.Kind))
+                            {
+                                return ParseCompoundAssignment(expression);
+                            }
+
                             var semicolonToken = TryMatchSemicolon();
                             var node = SyntaxFactory.ExpressionStatement(expression, semicolonToken);
                             if (expression.Kind is not (SyntaxKind.FunctionCallExpression or SyntaxKind.MethodCallExpression))
+                            {
                                 node = AddError(node, ErrorCode.ERR_NonFunctionCallBeingUsedAsStatement);
+                            }
+
                             return node;
                         }
                     }
@@ -714,7 +727,12 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
             }
             else
             {
-                return SyntaxFactory.BadExpression(EatToken());
+                var node = CreateMissingIdentifierName();
+                if (CurrentToken.Kind == SyntaxKind.EndOfFileToken)
+                    node = AddError(node, ErrorCode.ERR_ExpressionExpected);
+                else
+                    node = AddError(node, ErrorCode.ERR_InvalidExpressionPart, SyntaxFacts.GetText(CurrentToken.Kind));
+                return node;
             }
 
             var pos = -1;

--- a/src/Compilers/Lua/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/Lua/Portable/Parser/LanguageParser.cs
@@ -635,12 +635,16 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
             var kind = SyntaxFacts.GetCompoundAssignmentStatement(assignmentOperatorToken.Kind).Value;
             var expression = ParseExpression();
             var semicolonToken = TryMatchSemicolon();
-            return SyntaxFactory.CompoundAssignmentStatement(
+
+            var compoundAssignment = SyntaxFactory.CompoundAssignmentStatement(
                 kind,
                 variable,
                 assignmentOperatorToken,
                 expression,
                 semicolonToken);
+            if (!Options.SyntaxOptions.AcceptCompoundAssignment)
+                compoundAssignment = AddError(compoundAssignment, ErrorCode.ERR_CompoundAssignmentNotSupportedInLuaVersion);
+            return compoundAssignment;
         }
 
         internal ExpressionSyntax ParseExpression() =>

--- a/src/Compilers/Lua/Portable/Script/ScopeAndVariableManager.GotoWalker.cs
+++ b/src/Compilers/Lua/Portable/Script/ScopeAndVariableManager.GotoWalker.cs
@@ -23,6 +23,8 @@ namespace Loretta.CodeAnalysis.Lua
             public override void VisitGotoStatement(GotoStatementSyntax node)
             {
                 var scope = FindScope(node) ?? throw new System.Exception("Scope not found for node.");
+                if (string.IsNullOrWhiteSpace(node.LabelName.Text))
+                    return;
                 var label = scope.GetOrCreateLabel(node.LabelName.Text);
                 label.AddJump(node);
                 _labels[node] = label;

--- a/src/Compilers/Lua/Portable/Script/ScopeAndVariableManager.ScopeAndVariableWalker.cs
+++ b/src/Compilers/Lua/Portable/Script/ScopeAndVariableManager.ScopeAndVariableWalker.cs
@@ -124,6 +124,8 @@ namespace Loretta.CodeAnalysis.Lua
 
             public override void VisitIdentifierName(IdentifierNameSyntax node)
             {
+                if (node.IsMissing || string.IsNullOrWhiteSpace(node.Name))
+                    return;
                 var variable = GetVariableOrCreateGlobal(node.Name);
                 _variables.Add(node, variable);
                 variable.AddReadLocation(node);
@@ -141,6 +143,8 @@ namespace Loretta.CodeAnalysis.Lua
                 {
                     if (assignee is IdentifierNameSyntax identifierName)
                     {
+                        if (identifierName.IsMissing || string.IsNullOrWhiteSpace(identifierName.Name))
+                            continue;
                         var variable = GetVariableOrCreateGlobal(identifierName.Name);
                         _variables.Add(assignee, variable);
                         variable.AddWriteLocation(node);
@@ -161,6 +165,8 @@ namespace Loretta.CodeAnalysis.Lua
 
                 if (node.Variable is IdentifierNameSyntax identifierName)
                 {
+                    if (identifierName.IsMissing || string.IsNullOrWhiteSpace(identifierName.Name))
+                        return;
                     var variable = GetVariableOrCreateGlobal(identifierName.Name);
                     _variables.Add(identifierName, variable);
                     variable.AddWriteLocation(node);
@@ -183,6 +189,8 @@ namespace Loretta.CodeAnalysis.Lua
                 var scope = CreateBlockScope(node);
                 try
                 {
+                    if (node.Identifier.IsMissing || string.IsNullOrWhiteSpace(node.Identifier.Name))
+                        return;
                     var variable = scope.CreateVariable(VariableKind.Iteration, node.Identifier.Name, node);
                     _variables.Add(node.Identifier, variable);
                     Visit(node.Body);
@@ -202,6 +210,8 @@ namespace Loretta.CodeAnalysis.Lua
                 {
                     foreach (var identifierName in node.Identifiers)
                     {
+                        if (identifierName.IsMissing || string.IsNullOrWhiteSpace(identifierName.Name))
+                            continue;
                         var variable = scope.CreateVariable(VariableKind.Iteration, identifierName.Name, node);
                         _variables.Add(identifierName, variable);
                     }
@@ -288,6 +298,8 @@ namespace Loretta.CodeAnalysis.Lua
                     Visit(values);
                 foreach (var name in node.Names)
                 {
+                    if (name.IsMissing || string.IsNullOrWhiteSpace(name.Name))
+                        continue;
                     var variable = Scope.CreateVariable(VariableKind.Local, name.Name, node);
                     _variables.Add(name, variable);
                     variable.AddWriteLocation(node);
@@ -298,11 +310,14 @@ namespace Loretta.CodeAnalysis.Lua
 
             public override void VisitLocalFunctionDeclarationStatement(LocalFunctionDeclarationStatementSyntax node)
             {
-                var variable = Scope.CreateVariable(VariableKind.Local, node.Name.Name, node);
-                _variables.Add(node.Name, variable);
-                variable.AddWriteLocation(node);
-                variable.AddReferencingScope(Scope);
-                Scope.AddReferencedVariable(variable);
+                if (!node.Name.IsMissing && !string.IsNullOrWhiteSpace(node.Name.Name))
+                {
+                    var variable = Scope.CreateVariable(VariableKind.Local, node.Name.Name, node);
+                    _variables.Add(node.Name, variable);
+                    variable.AddWriteLocation(node);
+                    variable.AddReferencingScope(Scope);
+                    Scope.AddReferencedVariable(variable);
+                }
 
                 var scope = CreateFunctionScope(node);
                 try

--- a/src/Compilers/Lua/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/Lua/Portable/Syntax/Syntax.xml
@@ -756,24 +756,6 @@
     </TypeComment>
   </AbstractNode>
 
-  <Node Name="BadExpressionSyntax" Base="PrefixExpressionSyntax" NoFactory="true">
-    <PropertyComment>
-      <summary>Represents a bad input where an expression was expected.</summary>
-      <implnotes>This is just a bad stopgap measure, the parser should be improved instead.</implnotes>
-    </PropertyComment>
-    <FactoryComment>
-      <summary>
-        Creates a new <see cref="BadExpressionSyntax" /> node.
-      </summary>
-    </FactoryComment>
-    <Kind Name="BadExpression" />
-    <Field Name="Token" Type="SyntaxToken">
-      <PropertyComment>
-        <summary>The token containing the bad input.</summary>
-      </PropertyComment>
-    </Field>
-  </Node>
-
   <Node Name="ParenthesizedExpressionSyntax" Base="PrefixExpressionSyntax">
     <PropertyComment>
       <summary>Represents a parenthesized expression.</summary>
@@ -1399,29 +1381,6 @@
         <summary>The 'continue' keyword.</summary>
       </PropertyComment>
       <Kind Name="ContinueKeyword" />
-    </Field>
-    <Field Name="SemicolonToken" Type="SyntaxToken" Optional="true" Override="true">
-      <PropertyComment>
-        <summary>The semicolon at the end of the statement (if any).</summary>
-      </PropertyComment>
-      <Kind Name="SemicolonToken" />
-    </Field>
-  </Node>
-
-  <Node Name="BadStatementSyntax" Base="StatementSyntax" NoFactory="true">
-    <TypeComment>
-      <summary>Represents a bad statement.</summary>
-    </TypeComment>
-    <FactoryComment>
-      <summary>
-        Creates a new <see cref="BadStatementSyntax" /> node.
-      </summary>
-    </FactoryComment>
-    <Kind Name="BadStatement" />
-    <Field Name="Expression" Type="BadExpressionSyntax">
-      <PropertyComment>
-        <summary>The bad expression contained by the statement.</summary>
-      </PropertyComment>
     </Field>
     <Field Name="SemicolonToken" Type="SyntaxToken" Optional="true" Override="true">
       <PropertyComment>

--- a/src/Compilers/Lua/Portable/Syntax/SyntaxKind.cs
+++ b/src/Compilers/Lua/Portable/Syntax/SyntaxKind.cs
@@ -608,7 +608,6 @@ namespace Loretta.CodeAnalysis.Lua
         ExclusiveOrExpression = 2079,
 
         // Expressions
-        BadExpression = 2039,
         ParenthesizedExpression = 2040,
         FunctionCallExpression = 2041,
         [ExtraCategories(SyntaxKindCategory.VariableExpression)]
@@ -658,7 +657,6 @@ namespace Loretta.CodeAnalysis.Lua
         ContinueStatement = 2063,
 
         // Statements
-        BadStatement = 2064,
         LocalVariableDeclarationStatement = 2065,
         [ExtraCategories(SyntaxKindCategory.FunctionExpressionOrDeclaration)]
         LocalFunctionDeclarationStatement = 2066,

--- a/src/Compilers/Lua/Portable/Syntax/SyntaxKind.cs
+++ b/src/Compilers/Lua/Portable/Syntax/SyntaxKind.cs
@@ -668,7 +668,7 @@ namespace Loretta.CodeAnalysis.Lua
         StatementList = 2072,
         EmptyStatement = 2073,
 
-        // Big gap 2076-3001 (insert new nodes here)
+        // Big gap 2082-3001 (insert new nodes here)
 
         // Other types of nodes
         CompilationUnit = 3001,

--- a/src/Compilers/Lua/Test/Syntax/Lexical/LexicalErrorTests.cs
+++ b/src/Compilers/Lua/Test/Syntax/Lexical/LexicalErrorTests.cs
@@ -288,12 +288,21 @@ local num4 = 0xf_f
         {
             const string source = @"$\?";
             ParseAndValidate(source, null,
+                // (1,1): error LUA1012: Invalid statement
+                // $\?
+                Diagnostic(ErrorCode.ERR_InvalidStatement, "$").WithLocation(1, 1),
                 // (1,1): error LUA0014: Bad character input: '$'
                 // $\?
                 Diagnostic(ErrorCode.ERR_BadCharacter, "$").WithArguments("$").WithLocation(1, 1),
+                // (1,2): error LUA1012: Invalid statement
+                // $\?
+                Diagnostic(ErrorCode.ERR_InvalidStatement, @"\").WithLocation(1, 2),
                 // (1,2): error LUA0014: Bad character input: '\'
                 // $\?
-                Diagnostic(ErrorCode.ERR_BadCharacter, @"\").WithArguments(@"\").WithLocation(1, 2),
+                Diagnostic(ErrorCode.ERR_BadCharacter, @"\").WithArguments("\\").WithLocation(1, 2),
+                // (1,3): error LUA1012: Invalid statement
+                // $\?
+                Diagnostic(ErrorCode.ERR_InvalidStatement, "").WithLocation(1, 3),
                 // (1,3): error LUA0014: Bad character input: '?'
                 // $\?
                 Diagnostic(ErrorCode.ERR_BadCharacter, "?").WithArguments("?").WithLocation(1, 3));

--- a/src/Compilers/Lua/Test/Syntax/Lexical/LexicalTests.cs
+++ b/src/Compilers/Lua/Test/Syntax/Lexical/LexicalTests.cs
@@ -89,13 +89,13 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.UnitTests.Lexical
             var tokens = Lex($"\n{shebang}").ToImmutableArray();
             var expectedBrokenTokens = new[]
             {
-                new ShortToken ( SyntaxKind.HashToken, "#", new TextSpan ( 1, 1 ) ),
-                new ShortToken ( SyntaxKind.BangToken, "!", new TextSpan ( 2, 1 ) ),
-                new ShortToken ( SyntaxKind.SlashToken, "/", new TextSpan ( 3, 1 ) ),
-                new ShortToken ( SyntaxKind.IdentifierToken, "bin", new TextSpan ( 4, 3 ) ),
-                new ShortToken ( SyntaxKind.SlashToken, "/", new TextSpan ( 7, 1 ) ),
-                new ShortToken ( SyntaxKind.IdentifierToken, "bash", new TextSpan ( 8, 4 ) ),
-                new ShortToken ( SyntaxKind.EndOfFileToken, "", new TextSpan ( 12, 0 ) ),
+                new ShortToken(SyntaxKind.HashToken, "#", new TextSpan(1, 1)),
+                new ShortToken(SyntaxKind.BangToken, "!", new TextSpan(2, 1)),
+                new ShortToken(SyntaxKind.SlashToken, "/", new TextSpan(3, 1)),
+                new ShortToken(SyntaxKind.IdentifierToken, "bin", new TextSpan(4, 3)),
+                new ShortToken(SyntaxKind.SlashToken, "/", new TextSpan(7, 1)),
+                new ShortToken(SyntaxKind.IdentifierToken, "bash", new TextSpan(8, 4)),
+                new ShortToken(SyntaxKind.EndOfFileToken, "", new TextSpan(12, 0)),
             };
 
             Assert.Equal(expectedBrokenTokens.Length, tokens.Length);


### PR DESCRIPTION
Fixes the following errors:
- Missing expressions don't generate errors.
- Missing statements don't generate errors.
- Compound assignments don't generate errors when `AcceptCompoundAssignments` is false.