### PR TITLE
Implement FiveM hash strings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Added support for FiveM's hash strings (thanks to @TheGreatSageEqualToHeaven).
 
 ## v0.2.7-beta.5
 ### Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Added support for FiveM's hash strings (thanks to @TheGreatSageEqualToHeaven).
+  NOTE: There is currently no support for creating hash string literal nodes from `SyntaxFactory` because the API for
+  that still hasn't been decided on. If you need to create a node for it use `SyntaxFactory.ParseExpression`.
 
 ## v0.2.7-beta.5
 ### Added

--- a/src/Compilers/Core/Portable/InternalUtilities/Hash.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/Hash.cs
@@ -380,7 +380,7 @@ namespace Loretta.Utilities
         /// </summary>
         /// <param name="input">The string that will get hashed</param>
         /// <returns>The hash of <paramref name="input"/></returns>
-        public static uint JenkinsOneAtATimeHash(ReadOnlySpan<char> input)
+        public static uint GetJenkinsOneAtATimeHashCode(ReadOnlySpan<char> input)
         {
             uint hash = 0;
             var len = input.Length;

--- a/src/Compilers/Core/Portable/InternalUtilities/Hash.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/Hash.cs
@@ -373,5 +373,30 @@ namespace Loretta.Utilities
         {
             return unchecked((hashCode ^ ch) * Hash.FnvPrime);
         }
+
+        /// <summary>
+        /// Jenkins's one_at_a_time hash is adapted here from a WWW page by Bob Jenkins
+        /// See https://en.wikipedia.org/wiki/Jenkins_hash_function
+        /// </summary>
+        /// <param name="input">The string that will get hashed</param>
+        /// <returns>The hash of <paramref name="input"/></returns>
+        public static uint JenkinsOneAtATimeHash(ReadOnlySpan<char> input)
+        {
+            uint hash = 0;
+            var len = input.Length;
+
+            foreach (var c in input)
+            {
+                hash += c;
+                hash += (hash << 10);
+                hash ^= (hash >> 6);
+            }
+
+            hash += (hash << 3);
+            hash ^= (hash >> 11);
+            hash += (hash << 15);
+
+            return hash;
+        }
     }
 }

--- a/src/Compilers/Lua/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/Lua/Portable/Errors/ErrorCode.cs
@@ -34,6 +34,7 @@
         ERR_EscapeTooLarge = 26,
         ERR_HexDigitExpected = 27,
         ERR_UnicodeEscapesNotSupportedLuaInVersion = 28,
+        ERR_HashStringsNotSupportedInVersion = 29,
 
         // Parser Errors
         ERR_IdentifierExpectedKW = 1000,

--- a/src/Compilers/Lua/Portable/LuaResources.Designer.cs
+++ b/src/Compilers/Lua/Portable/LuaResources.Designer.cs
@@ -169,6 +169,15 @@ namespace Loretta.CodeAnalysis.Lua {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Hash strings are not supported in this lua version.
+        /// </summary>
+        internal static string ERR_HashStringsNotSupportedInVersion {
+            get {
+                return ResourceManager.GetString("ERR_HashStringsNotSupportedInVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Hexadecimal digit expected.
         /// </summary>
         internal static string ERR_HexDigitExpected {

--- a/src/Compilers/Lua/Portable/LuaResources.resx
+++ b/src/Compilers/Lua/Portable/LuaResources.resx
@@ -155,6 +155,9 @@
   <data name="ERR_ExpressionExpected" xml:space="preserve">
     <value>Expression expected</value>
   </data>
+  <data name="ERR_HashStringsNotSupportedInVersion" xml:space="preserve">
+    <value>Hash strings are not supported in this lua version</value>
+  </data>
   <data name="ERR_HexDigitExpected" xml:space="preserve">
     <value>Hexadecimal digit expected</value>
   </data>

--- a/src/Compilers/Lua/Portable/LuaSyntaxOptions.cs
+++ b/src/Compilers/Lua/Portable/LuaSyntaxOptions.cs
@@ -33,7 +33,8 @@ namespace Loretta.CodeAnalysis.Lua
             acceptWhitespaceEscape: false,
             acceptUnicodeEscape: false,
             continueType: ContinueType.None,
-            acceptIfExpression: true);
+            acceptIfExpression: true,
+            acceptHashStrings: false);
 
         /// <summary>
         /// The Lua 5.2 preset.
@@ -72,7 +73,8 @@ namespace Loretta.CodeAnalysis.Lua
             acceptWhitespaceEscape: true,
             acceptUnicodeEscape: false,
             continueType: ContinueType.None,
-            acceptIfExpression: false);
+            acceptIfExpression: false,
+            acceptHashStrings: false);
 
         /// <summary>
         /// The LuaJIT 2.1-beta3 preset.
@@ -109,7 +111,14 @@ namespace Loretta.CodeAnalysis.Lua
             acceptWhitespaceEscape: true,
             acceptUnicodeEscape: true,
             continueType: ContinueType.ContextualKeyword,
-            acceptIfExpression: true);
+            acceptIfExpression: true,
+            acceptHashStrings: false);
+
+        /// <summary>
+        /// The FiveM preset.
+        /// </summary>
+        public static readonly LuaSyntaxOptions FiveM = Lua53.With(
+            acceptHashStrings: true);
 
         /// <summary>
         /// The preset that sets everything to true and continue to <see
@@ -132,7 +141,8 @@ namespace Loretta.CodeAnalysis.Lua
             acceptWhitespaceEscape: true,
             acceptUnicodeEscape: true,
             continueType: ContinueType.ContextualKeyword,
-            acceptIfExpression: true);
+            acceptIfExpression: true,
+            acceptHashStrings: true);
 
         /// <summary>
         /// All presets that are preconfigured in <see cref="LuaSyntaxOptions"/>.
@@ -169,6 +179,7 @@ namespace Loretta.CodeAnalysis.Lua
         /// <param name="acceptUnicodeEscape"><inheritdoc cref="AcceptUnicodeEscape" path="/summary"/></param>
         /// <param name="continueType"><inheritdoc cref="ContinueType" path="/summary" /></param>
         /// <param name="acceptIfExpression"><inheritdoc cref="AcceptIfExpressions" path="/summary" /></param>
+        /// <param name="acceptHashStrings"><inheritdoc cref="AcceptHashStrings" path="/summary" /></param>
         public LuaSyntaxOptions(
             bool acceptBinaryNumbers,
             bool acceptCCommentSyntax,
@@ -186,7 +197,8 @@ namespace Loretta.CodeAnalysis.Lua
             bool acceptWhitespaceEscape,
             bool acceptUnicodeEscape,
             ContinueType continueType,
-            bool acceptIfExpression)
+            bool acceptIfExpression,
+            bool acceptHashStrings)
         {
             AcceptBinaryNumbers = acceptBinaryNumbers;
             AcceptCCommentSyntax = acceptCCommentSyntax;
@@ -205,6 +217,7 @@ namespace Loretta.CodeAnalysis.Lua
             AcceptUnicodeEscape = acceptUnicodeEscape;
             ContinueType = continueType;
             AcceptIfExpressions = acceptIfExpression;
+            AcceptHashStrings = acceptHashStrings;
         }
 
         /// <summary>
@@ -296,6 +309,11 @@ namespace Loretta.CodeAnalysis.Lua
         public bool AcceptIfExpressions { get; }
 
         /// <summary>
+        /// Whether to accept FiveM hash strings.
+        /// </summary>
+        public bool AcceptHashStrings { get; }
+
+        /// <summary>
         /// Creates a new lua options changing the provided fields.
         /// </summary>
         /// <param name="acceptBinaryNumbers">
@@ -366,6 +384,10 @@ namespace Loretta.CodeAnalysis.Lua
         /// <inheritdoc cref="AcceptIfExpressions" path="/summary" /> If None uses the value of
         /// <see cref="AcceptIfExpressions" />.
         /// </param>
+        /// <param name="acceptHashStrings">
+        /// <inheritdoc cref="AcceptHashStrings" path="/summary" /> If None uses the value of
+        /// <see cref="AcceptHashStrings" />.
+        /// </param>
         /// <returns></returns>
         public LuaSyntaxOptions With(
             Option<bool> acceptBinaryNumbers = default,
@@ -384,7 +406,8 @@ namespace Loretta.CodeAnalysis.Lua
             Option<bool> acceptWhitespaceEscape = default,
             Option<bool> acceptUnicodeEscape = default,
             Option<ContinueType> continueType = default,
-            Option<bool> acceptIfExpression = default) =>
+            Option<bool> acceptIfExpression = default,
+            Option<bool> acceptHashStrings = default) =>
             new LuaSyntaxOptions(
                 acceptBinaryNumbers.UnwrapOr(AcceptBinaryNumbers),
                 acceptCCommentSyntax.UnwrapOr(AcceptCCommentSyntax),
@@ -402,7 +425,8 @@ namespace Loretta.CodeAnalysis.Lua
                 acceptWhitespaceEscape.UnwrapOr(AcceptWhitespaceEscape),
                 acceptUnicodeEscape.UnwrapOr(AcceptUnicodeEscape),
                 continueType.UnwrapOr(ContinueType),
-                acceptIfExpression.UnwrapOr(AcceptIfExpressions));
+                acceptIfExpression.UnwrapOr(AcceptIfExpressions),
+                acceptHashStrings.UnwrapOr(AcceptHashStrings));
 
         /// <inheritdoc/>
         public override bool Equals(object? obj) =>
@@ -427,7 +451,8 @@ namespace Loretta.CodeAnalysis.Lua
                 && AcceptBitwiseOperators == other.AcceptBitwiseOperators
                 && AcceptWhitespaceEscape == other.AcceptWhitespaceEscape
                 && ContinueType == other.ContinueType
-                && AcceptIfExpressions == other.AcceptIfExpressions);
+                && AcceptIfExpressions == other.AcceptIfExpressions
+                && AcceptHashStrings == other.AcceptHashStrings);
 
         /// <inheritdoc/>
         public override int GetHashCode()
@@ -449,6 +474,7 @@ namespace Loretta.CodeAnalysis.Lua
             hash.Add(AcceptWhitespaceEscape);
             hash.Add(ContinueType);
             hash.Add(AcceptIfExpressions);
+            hash.Add(AcceptHashStrings);
             return hash.ToHashCode();
         }
 
@@ -479,13 +505,17 @@ namespace Loretta.CodeAnalysis.Lua
             {
                 return "Roblox";
             }
+            else if (this == FiveM)
+            {
+                return "FiveM";
+            }
             else if (this == All)
             {
                 return "All";
             }
             else
             {
-                return $"{{ AcceptBinaryNumbers = {AcceptBinaryNumbers}, AcceptCCommentSyntax = {AcceptCCommentSyntax}, AcceptCompoundAssignment = {AcceptCompoundAssignment}, AcceptEmptyStatements = {AcceptEmptyStatements}, AcceptCBooleanOperators = {AcceptCBooleanOperators}, AcceptGoto = {AcceptGoto}, AcceptHexEscapesInStrings = {AcceptHexEscapesInStrings}, AcceptHexFloatLiterals = {AcceptHexFloatLiterals}, AcceptOctalNumbers = {AcceptOctalNumbers}, AcceptShebang = {AcceptShebang}, AcceptUnderscoreInNumberLiterals = {AcceptUnderscoreInNumberLiterals}, UseLuaJitIdentifierRules = {UseLuaJitIdentifierRules}, AcceptBitwiseOperators = {AcceptBitwiseOperators}, AcceptWhitespaceEscape = {AcceptWhitespaceEscape}, ContinueType = {ContinueType}, AcceptIfExpressions = {AcceptIfExpressions} }}";
+                return $"{{ AcceptBinaryNumbers = {AcceptBinaryNumbers}, AcceptCCommentSyntax = {AcceptCCommentSyntax}, AcceptCompoundAssignment = {AcceptCompoundAssignment}, AcceptEmptyStatements = {AcceptEmptyStatements}, AcceptCBooleanOperators = {AcceptCBooleanOperators}, AcceptGoto = {AcceptGoto}, AcceptHexEscapesInStrings = {AcceptHexEscapesInStrings}, AcceptHexFloatLiterals = {AcceptHexFloatLiterals}, AcceptOctalNumbers = {AcceptOctalNumbers}, AcceptShebang = {AcceptShebang}, AcceptUnderscoreInNumberLiterals = {AcceptUnderscoreInNumberLiterals}, UseLuaJitIdentifierRules = {UseLuaJitIdentifierRules}, AcceptBitwiseOperators = {AcceptBitwiseOperators}, AcceptWhitespaceEscape = {AcceptWhitespaceEscape}, ContinueType = {ContinueType}, AcceptIfExpressions = {AcceptIfExpressions}, AcceptHashStrings ={AcceptHashStrings} }}";
             }
         }
 

--- a/src/Compilers/Lua/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/Lua/Portable/Parser/LanguageParser.cs
@@ -709,7 +709,8 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                 or SyntaxKind.TrueKeyword
                 or SyntaxKind.FalseKeyword
                 or SyntaxKind.NumericLiteralToken
-                or SyntaxKind.StringLiteralToken => ParseLiteralExpression(),
+                or SyntaxKind.StringLiteralToken
+                or SyntaxKind.HashStringLiteralToken => ParseLiteralExpression(),
                 SyntaxKind.DotDotDotToken => ParseVarArgExpression(),
                 SyntaxKind.OpenBraceToken => ParseTableConstructorExpression(),
                 SyntaxKind.FunctionKeyword when PeekToken(1).Kind == SyntaxKind.OpenParenthesisToken => ParseAnonymousFunctionExpression(),

--- a/src/Compilers/Lua/Portable/Parser/Lexer.ShortString.cs
+++ b/src/Compilers/Lua/Portable/Parser/Lexer.ShortString.cs
@@ -9,7 +9,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
         {
             _builder.Clear();
             var delim = _reader.Read()!.Value;
-            RoslynDebug.Assert(delim is '"' or '\'');
+            RoslynDebug.Assert(delim is '"' or '\'' or '`');
 
             while (_reader.Peek() is char peek && peek != delim)
             {

--- a/src/Compilers/Lua/Portable/Parser/Lexer.cs
+++ b/src/Compilers/Lua/Portable/Parser/Lexer.cs
@@ -708,7 +708,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                     var stringValue = ParseShortString();
                     // Jenkins' one-at-a-time hash doesn't do this but FiveM does.
                     stringValue = stringValue.ToLowerInvariant();
-                    info.UIntValue = Hash.JenkinsOneAtATimeHash(stringValue.AsSpan());
+                    info.UIntValue = Hash.GetJenkinsOneAtATimeHashCode(stringValue.AsSpan());
                     info.Text = GetText(intern: true);
                     return;
                 }

--- a/src/Compilers/Lua/Portable/Parser/Lexer.cs
+++ b/src/Compilers/Lua/Portable/Parser/Lexer.cs
@@ -26,6 +26,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
             internal string? Text;
             internal string? StringValue;
             internal double DoubleValue;
+            internal uint UIntValue;
         }
 
         private readonly LexerCache _cache = new LexerCache();
@@ -112,6 +113,10 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 
                 case SyntaxKind.StringLiteralToken:
                     token = SyntaxFactory.Literal(leadingNode, info.Text!, info.StringValue!, trailingNode);
+                    break;
+
+                case SyntaxKind.HashStringLiteralToken:
+                    token = SyntaxFactory.HashLiteral(leadingNode, info.Text!, info.UIntValue, trailingNode);
                     break;
 
                 case SyntaxKind.EndOfFileToken:
@@ -693,6 +698,17 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                 {
                     info.Kind = SyntaxKind.StringLiteralToken;
                     info.StringValue = ParseShortString();
+                    info.Text = GetText(intern: true);
+                    return;
+                }
+
+                case '`':
+                {
+                    info.Kind = SyntaxKind.HashStringLiteralToken;
+                    var stringValue = ParseShortString();
+                    // Jenkins' one-at-a-time hash doesn't do this but FiveM does.
+                    stringValue = stringValue.ToLowerInvariant();
+                    info.UIntValue = Hash.JenkinsOneAtATimeHash(stringValue.AsSpan());
                     info.Text = GetText(intern: true);
                     return;
                 }

--- a/src/Compilers/Lua/Portable/Parser/Lexer.cs
+++ b/src/Compilers/Lua/Portable/Parser/Lexer.cs
@@ -710,6 +710,10 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                     stringValue = stringValue.ToLowerInvariant();
                     info.UIntValue = Hash.GetJenkinsOneAtATimeHashCode(stringValue.AsSpan());
                     info.Text = GetText(intern: true);
+
+                    if (!Options.SyntaxOptions.AcceptHashStrings)
+                        AddError(ErrorCode.ERR_HashStringsNotSupportedInVersion);
+
                     return;
                 }
 

--- a/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxFactory.cs
+++ b/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxFactory.cs
@@ -128,6 +128,9 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
         internal static SyntaxToken Literal(GreenNode? leading, string text, SyntaxKind kind, string value, GreenNode? trailing) =>
             SyntaxToken.WithValue(kind, leading, text, value, trailing);
 
+        internal static SyntaxToken HashLiteral(GreenNode? leading, string text, uint value, GreenNode? trailing) =>
+            SyntaxToken.WithValue(SyntaxKind.HashStringLiteralToken, leading, text, value, trailing);
+
         internal static SyntaxToken BadToken(GreenNode? leading, string text, GreenNode? trailing) =>
             SyntaxToken.WithValue(SyntaxKind.BadToken, leading, text, text, trailing);
 

--- a/src/Compilers/Lua/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/Lua/Portable/Syntax/Syntax.xml
@@ -445,6 +445,7 @@
     <Kind Name="TrueLiteralExpression" />
     <Kind Name="FalseLiteralExpression" />
     <Kind Name="NilLiteralExpression" />
+    <Kind Name="HashStringLiteralExpression" />
     <Field Name="Token" Type="SyntaxToken">
       <PropertyComment>
         <summary>The literal token.</summary>
@@ -454,6 +455,7 @@
       <Kind Name="TrueKeyword" />
       <Kind Name="FalseKeyword" />
       <Kind Name="NilKeyword" />
+      <Kind Name="HashStringLiteralToken" />
     </Field>
   </Node>
 

--- a/src/Compilers/Lua/Portable/Syntax/SyntaxKind.cs
+++ b/src/Compilers/Lua/Portable/Syntax/SyntaxKind.cs
@@ -496,8 +496,12 @@ namespace Loretta.CodeAnalysis.Lua
         StringLiteralToken = 1002,
         [Token]
         IdentifierToken = 1003,
+        [Token]
+        [ExtraCategories(SyntaxKindCategory.LiteralToken)]
+        [Property(SyntaxKindProperty.LiteralExpression, HashStringLiteralExpression)]
+        HashStringLiteralToken = 1004,
 
-        // Big gap 1003-2000 (insert new tokens with text here)
+        // Big gap 1005-2000 (insert new tokens with text here)
 
         // Parameters
         NamedParameter = 2000,
@@ -533,6 +537,7 @@ namespace Loretta.CodeAnalysis.Lua
         IdentifierName = 2020,
         IfExpression = 2080,
         ElseIfExpressionClause = 2081,
+        HashStringLiteralExpression = 2082,
 
         // Unary Expressions
         [ExtraCategories(SyntaxKindCategory.UnaryExpression)]
@@ -671,7 +676,7 @@ namespace Loretta.CodeAnalysis.Lua
         StatementList = 2072,
         EmptyStatement = 2073,
 
-        // Big gap 2082-3001 (insert new nodes here)
+        // Big gap 2083-3001 (insert new nodes here)
 
         // Other types of nodes
         CompilationUnit = 3001,

--- a/src/Compilers/Lua/Test/Syntax/Lexical/LexicalErrorTests.cs
+++ b/src/Compilers/Lua/Test/Syntax/Lexical/LexicalErrorTests.cs
@@ -423,5 +423,21 @@ local str4 = 'hello\xFFthere'
                 // local b = '\u{FEBE}'
                 Diagnostic(ErrorCode.ERR_UnicodeEscapesNotSupportedLuaInVersion, @"\u{FEBE}").WithLocation(2, 12));
         }
+
+        [Fact]
+        [Trait("Category", "Lexer/Diagnostics")]
+        public void Lexer_EmitsDiagnosticsWhen_HashStringsAreFound_And_LuaSyntaxOptionsAcceptHashStringsIsFalse()
+        {
+            const string source = "local a = `hello`\r\n" +
+                "local b = `hi!`";
+            var options = LuaSyntaxOptions.All.With(acceptHashStrings: false);
+            ParseAndValidate(source, options,
+                // (1,11): error LUA0029: Hash strings are not supported in this lua version
+                // local a = `hello`
+                Diagnostic(ErrorCode.ERR_HashStringsNotSupportedInVersion, "`hello`").WithLocation(1, 11),
+                // (2,11): error LUA0029: Hash strings are not supported in this lua version
+                // local b = `hi!`
+                Diagnostic(ErrorCode.ERR_HashStringsNotSupportedInVersion, "`hi!`").WithLocation(2, 11));
+        }
     }
 }

--- a/src/Compilers/Lua/Test/Syntax/Lexical/LexicalTestData.cs
+++ b/src/Compilers/Lua/Test/Syntax/Lexical/LexicalTestData.cs
@@ -135,6 +135,11 @@ fourth line \xFF.";
                     longStringContent);
             }
 
+            yield return new ShortToken(
+                SyntaxKind.HashStringLiteralToken,
+                $"`{shortStringContentText}`",
+                Loretta.Utilities.Hash.GetJenkinsOneAtATimeHashCode(shortStringContentValue.AsSpan()));
+
             #endregion Strings
 
             // Identifiers

--- a/src/Compilers/Lua/Test/Syntax/SyntaxKindTests.cs
+++ b/src/Compilers/Lua/Test/Syntax/SyntaxKindTests.cs
@@ -29,6 +29,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.UnitTests.Syntax
                 SyntaxKind.NumericLiteralToken,
                 SyntaxKind.StringLiteralToken,
                 SyntaxKind.IdentifierToken,
+                SyntaxKind.HashStringLiteralToken,
             };
 
             foreach (var kind in kinds)


### PR DESCRIPTION
FiveM hash strings are a compile-time hash generated from a string.
It uses Jenkins' one-at-a-time hash but with the difference that it always converts the string to lower case before hashing it.

Original PR was #42 by @TheGreatSageEqualToHeaven and I've incorporated the changes because there were some things missing that weren't easy to explain how to do.

NOTE: There is currently no support for creating hash string literal nodes from `SyntaxFactory` because the API for that still hasn't been decided on. If you need to create a node for it use `SyntaxFactory.ParseExpression`.