### PR TITLE
Implement IVariable and IScope goodies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Added `IScope.ContainedScopes` which lets you check scopes contained within another scope.
 
 ## v0.2.7-beta.8
 ### Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `IScope.ContainedScopes` which lets you check scopes contained within another scope.
 
+### Changed
+- Renamed `IScope.Parent` to `IScope.ContainingScope` to be more consistent with `ContainedScopes`.
+
 ## v0.2.7-beta.8
 ### Added
 - Added a minifier to the experimental package.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `IScope.ContainedScopes` which lets you check scopes contained within another scope.
 - Added `IVariable.CanBeAccessedIn(IScope)` which lets you check if the variable can be accessed within a given scope.
+- Added `IScope.FindVariable(string)` which lets you try to find a variable in a scope or any of its parents.
 
 ### Changed
 - Renamed `IScope.Parent` to `IScope.ContainingScope` to be more consistent with `ContainedScopes`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `IScope.ContainedScopes` which lets you check scopes contained within another scope.
 - Added `IVariable.CanBeAccessedIn(IScope)` which lets you check if the variable can be accessed within a given scope.
 - Added `IScope.FindVariable(string)` which lets you try to find a variable in a scope or any of its parents.
+- Added `Script.RenameVariable(IVariable variable, string newName)` which lets you rename a variable in a new script instance.
 
 ### Changed
 - Renamed `IScope.Parent` to `IScope.ContainingScope` to be more consistent with `ContainedScopes`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Added `IScope.ContainedScopes` which lets you check scopes contained within another scope.
+- Added `IVariable.CanBeAccessedIn(IScope)` which lets you check if the variable can be accessed within a given scope.
 
 ### Changed
 - Renamed `IScope.Parent` to `IScope.ContainingScope` to be more consistent with `ContainedScopes`.

--- a/src/Compilers/Lua/Portable/Scoping/IScope.cs
+++ b/src/Compilers/Lua/Portable/Scoping/IScope.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Loretta.CodeAnalysis.Lua.Syntax;
@@ -27,7 +28,7 @@ namespace Loretta.CodeAnalysis.Lua
         /// <summary>
         /// The parent scope (if any).
         /// </summary>
-        IScope? Parent { get; }
+        IScope? ContainingScope { get; }
 
         /// <summary>
         /// Contains the variables declared within the scope.
@@ -37,7 +38,7 @@ namespace Loretta.CodeAnalysis.Lua
         IEnumerable<IVariable> DeclaredVariables { get; }
 
         /// <summary>
-        /// Variables that are referenced by this scope.
+        /// Variables that are directly referenced by this scope.
         /// </summary>
         IEnumerable<IVariable> ReferencedVariables { get; }
 
@@ -50,6 +51,13 @@ namespace Loretta.CodeAnalysis.Lua
         /// Returns the scopes directly contained within this scope.
         /// </summary>
         IEnumerable<IScope> ContainedScopes { get; }
+
+        /// <summary>
+        /// Deprecated. <inheritdoc cref="ContainingScope"/>
+        /// </summary>
+        [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use ContainingScope instead.")]
+        IScope? Parent => ContainingScope;
     }
 
     internal interface IScopeInternal : IScope
@@ -91,7 +99,7 @@ namespace Loretta.CodeAnalysis.Lua
 
         public IScopeInternal? Parent { get; }
 
-        IScope? IScope.Parent => Parent;
+        IScope? IScope.ContainingScope => Parent;
 
         public IEnumerable<IVariableInternal> DeclaredVariables { get; }
 
@@ -168,7 +176,7 @@ namespace Loretta.CodeAnalysis.Lua
 
         public void AddChildScope(IScopeInternal scope)
         {
-            RoslynDebug.Assert(scope.Parent == this);
+            RoslynDebug.Assert(scope.ContainingScope == this);
             _containedScopes.Add(scope);
         }
     }

--- a/src/Compilers/Lua/Portable/Scoping/IScope.cs
+++ b/src/Compilers/Lua/Portable/Scoping/IScope.cs
@@ -96,7 +96,7 @@ namespace Loretta.CodeAnalysis.Lua
         ///     </item>
         ///   </list>
         /// </remarks>
-        IVariable? FindVariable(string name, ScopeKind kind = ScopeKind.Block);
+        IVariable? FindVariable(string name, ScopeKind kind = ScopeKind.Global);
 
         /// <summary>
         /// Deprecated. <inheritdoc cref="ContainingScope"/>
@@ -164,7 +164,7 @@ namespace Loretta.CodeAnalysis.Lua
 
         IEnumerable<IScope> IScope.ContainedScopes => ContainedScopes;
 
-        public IVariable? FindVariable(string name, ScopeKind kind = ScopeKind.Block)
+        public IVariable? FindVariable(string name, ScopeKind kind = ScopeKind.Global)
         {
             if (name is null) throw new ArgumentNullException(nameof(name));
             if (!StringUtils.IsIdentifier(name)) throw new ArgumentException($"'{nameof(name)}' must be a valid identifier.");
@@ -173,7 +173,7 @@ namespace Loretta.CodeAnalysis.Lua
                 if (StringComparer.Ordinal.Equals(variable.Name, name))
                     return variable;
             }
-            return Parent is not null && Parent.Kind >= kind ? Parent.FindVariable(name) : null;
+            return Parent is not null && Parent.Kind >= kind ? Parent.FindVariable(name, kind) : null;
         }
 
         public bool TryGetVariable(string name, [NotNullWhen(true)] out IVariableInternal? variable) =>

--- a/src/Compilers/Lua/Portable/Scoping/IScope.cs
+++ b/src/Compilers/Lua/Portable/Scoping/IScope.cs
@@ -103,7 +103,7 @@ namespace Loretta.CodeAnalysis.Lua
         /// </summary>
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use ContainingScope instead.")]
-        IScope? Parent => ContainingScope;
+        IScope? Parent { get; }
     }
 
     internal interface IScopeInternal : IScope
@@ -146,6 +146,7 @@ namespace Loretta.CodeAnalysis.Lua
         public IScopeInternal? Parent { get; }
 
         IScope? IScope.ContainingScope => Parent;
+        IScope? IScope.Parent => Parent;
 
         public IEnumerable<IVariableInternal> DeclaredVariables { get; }
 

--- a/src/Compilers/Lua/Portable/Scoping/IVariable.cs
+++ b/src/Compilers/Lua/Portable/Scoping/IVariable.cs
@@ -52,6 +52,14 @@ namespace Loretta.CodeAnalysis.Lua
         /// All locations this variable is written to.
         /// </summary>
         IEnumerable<SyntaxNode> WriteLocations { get; }
+
+        /// <summary>
+        /// Returns whether this variable can be accessed in the
+        /// provided scope.
+        /// </summary>
+        /// <param name="scope">The scope to check access in.</param>
+        /// <returns></returns>
+        bool CanBeAccessedIn(IScope scope);
     }
 
     internal interface IVariableInternal : IVariable
@@ -105,6 +113,16 @@ namespace Loretta.CodeAnalysis.Lua
         public IEnumerable<SyntaxNode> ReadLocations { get; }
 
         public IEnumerable<SyntaxNode> WriteLocations { get; }
+
+        public bool CanBeAccessedIn(IScope scope)
+        {
+            for (IScope? currScope = scope; currScope != null; currScope = currScope.ContainingScope)
+            {
+                if (ContainingScope == currScope)
+                    return true;
+            }
+            return false;
+        }
 
         public void AddReferencingScope(IScopeInternal scope) =>
             _referencingScopes.Add(scope);

--- a/src/Compilers/Lua/Portable/Script/RenameErrors.cs
+++ b/src/Compilers/Lua/Portable/Script/RenameErrors.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Loretta.CodeAnalysis.Lua
+﻿namespace Loretta.CodeAnalysis.Lua
 {
     /// <summary>
     /// An error found while renaming a variable.
@@ -12,13 +8,13 @@ namespace Loretta.CodeAnalysis.Lua
     /// An error that represents the provided identifier not being supported
     /// in a provided tree.
     /// </summary>
-    /// <param name="SyntaxTree">
+    /// <param name="TreeWithoutSupport">
     /// The <see cref="SyntaxTree"/> the identifier name is not supported on.
     /// </param>
-    public record IdentifierNameNotSupportedError(SyntaxTree SyntaxTree) : RenameError;
+    public record IdentifierNameNotSupportedError(SyntaxTree TreeWithoutSupport) : RenameError;
     /// <summary>
     /// Represents a conflict with an existing variable.
     /// </summary>
-    /// <param name="Variable">The variable that is conflicted with.</param>
-    public record VariableConflictError(IVariable Variable) : RenameError;
+    /// <param name="VariableBeingConflictedWith">The variable that is conflicted with.</param>
+    public record VariableConflictError(IVariable VariableBeingConflictedWith) : RenameError;
 }

--- a/src/Compilers/Lua/Portable/Script/RenameErrors.cs
+++ b/src/Compilers/Lua/Portable/Script/RenameErrors.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Loretta.CodeAnalysis.Lua
+{
+    /// <summary>
+    /// An error found while renaming a variable.
+    /// </summary>
+    public record RenameError;
+    /// <summary>
+    /// An error that represents the provided identifier not being supported
+    /// in a provided tree.
+    /// </summary>
+    /// <param name="SyntaxTree">
+    /// The <see cref="SyntaxTree"/> the identifier name is not supported on.
+    /// </param>
+    public record IdentifierNameNotSupportedError(SyntaxTree SyntaxTree) : RenameError;
+    /// <summary>
+    /// Represents a conflict with an existing variable.
+    /// </summary>
+    /// <param name="Variable">The variable that is conflicted with.</param>
+    public record VariableConflictError(IVariable Variable) : RenameError;
+}

--- a/src/Compilers/Lua/Portable/Script/Script.RenameRewriter.cs
+++ b/src/Compilers/Lua/Portable/Script/Script.RenameRewriter.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Loretta.CodeAnalysis.Lua.Syntax;
+
+namespace Loretta.CodeAnalysis.Lua
+{
+    public sealed partial class Script
+    {
+        private sealed class RenameRewriter : LuaSyntaxRewriter
+        {
+            private readonly Script _script;
+            private readonly IVariable _variable;
+            private readonly string _newName;
+
+            public RenameRewriter(Script script, IVariable variable, string newName)
+            {
+                if (string.IsNullOrEmpty(newName)) throw new ArgumentException($"'{nameof(newName)}' cannot be null or empty.", nameof(newName));
+                _script = script ?? throw new ArgumentNullException(nameof(script));
+                _variable = variable ?? throw new ArgumentNullException(nameof(variable));
+                _newName = newName;
+            }
+
+            private SyntaxToken CreateIdentifier(SyntaxToken original)
+            {
+                var identifier = SyntaxFactory.Identifier(
+                    original.LeadingTrivia,
+                    original.ContextualKind(),
+                    _newName,
+                    original.TrailingTrivia);
+                return original.CopyAnnotationsTo(identifier);
+            }
+
+            public override SyntaxNode? VisitNamedParameter(NamedParameterSyntax node)
+            {
+                if (_script.GetVariable(node) == _variable)
+                    return node.Update(CreateIdentifier(node.Identifier));
+                return base.VisitNamedParameter(node);
+            }
+
+            public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
+            {
+                if (_script.GetVariable(node) == _variable)
+                    return node.Update(CreateIdentifier(node.Identifier));
+                return base.VisitIdentifierName(node);
+            }
+
+            public override SyntaxNode? VisitSimpleFunctionName(SimpleFunctionNameSyntax node)
+            {
+                if (_script.GetVariable(node) == _variable)
+                    return node.Update(CreateIdentifier(node.Name));
+                return base.VisitSimpleFunctionName(node);
+            }
+        }
+    }
+}

--- a/src/Compilers/Lua/Portable/Script/Script.cs
+++ b/src/Compilers/Lua/Portable/Script/Script.cs
@@ -150,7 +150,7 @@ namespace Loretta.CodeAnalysis.Lua
         {
             if (newName is null) throw new ArgumentNullException(nameof(newName));
 
-            var errors = ArrayBuilder<RenameError>.GetInstance();
+            var errors = new HashSet<RenameError>();
             var trees = new HashSet<SyntaxTree>();
             foreach (var location in variable.ReadLocations)
             {
@@ -173,7 +173,7 @@ namespace Loretta.CodeAnalysis.Lua
             }
 
             if (errors.Any())
-                return Result.Err<Script, IEnumerable<RenameError>>(errors.ToImmutableAndFree());
+                return Result.Err<Script, IEnumerable<RenameError>>(errors);
 
             var visitor = new RenameRewriter(this, variable, newName);
             var finalTrees = SyntaxTrees;

--- a/src/Compilers/Lua/Portable/Script/Script.cs
+++ b/src/Compilers/Lua/Portable/Script/Script.cs
@@ -188,9 +188,9 @@ namespace Loretta.CodeAnalysis.Lua
             void handleLocation(SyntaxNode location)
             {
                 trees.Add(location.SyntaxTree);
-                if (FindScope(location)?.FindVariable(newName) is not null)
+                if (FindScope(location)?.FindVariable(newName) is IVariable conflicting)
                 {
-                    errors.Add(new VariableConflictError(variable));
+                    errors.Add(new VariableConflictError(conflicting));
                 }
             }
         }

--- a/src/Compilers/Lua/Portable/Script/Script.cs
+++ b/src/Compilers/Lua/Portable/Script/Script.cs
@@ -1,12 +1,19 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
+using System.Xml.Linq;
+using Loretta.CodeAnalysis.Lua.Syntax;
+using Loretta.CodeAnalysis.PooledObjects;
+using Loretta.Utilities;
+using Tsu;
 
 namespace Loretta.CodeAnalysis.Lua
 {
     /// <summary>
     /// A script containing one or more files.
     /// </summary>
-    public sealed class Script
+    public sealed partial class Script
     {
         /// <summary>
         /// An empty script with no syntax trees.
@@ -127,6 +134,65 @@ namespace Loretta.CodeAnalysis.Lua
         {
             _scopeAndVariableManager.GetLazyState().Labels.TryGetValue(node, out var label);
             return label;
+        }
+
+        /// <summary>
+        /// Attempts to rename the provided variable with the new provided name.
+        /// </summary>
+        /// <param name="variable">The variable to rename.</param>
+        /// <param name="newName">The new variable's name.</param>
+        /// <returns>
+        /// An Ok(Script) if the rename was successful or
+        /// an Err(IEnumerable&lt;RenameError&gt;) if there were errors
+        /// while renaming the variable.
+        /// </returns>
+        public Result<Script, IEnumerable<RenameError>> RenameVariable(IVariable variable, string newName)
+        {
+            if (newName is null) throw new ArgumentNullException(nameof(newName));
+
+            var errors = ArrayBuilder<RenameError>.GetInstance();
+            var trees = new HashSet<SyntaxTree>();
+            foreach (var location in variable.ReadLocations)
+            {
+                handleLocation(location);
+            }
+            foreach (var location in variable.WriteLocations)
+            {
+                handleLocation(location);
+            }
+            if (variable.Declaration is not null)
+                handleLocation(variable.Declaration);
+
+            if (newName.Any(static c => c >= 0x7F))
+            {
+                foreach (var tree in trees)
+                {
+                    if (!((LuaParseOptions) tree.Options).SyntaxOptions.UseLuaJitIdentifierRules)
+                        errors.Add(new IdentifierNameNotSupportedError(tree));
+                }
+            }
+
+            if (errors.Any())
+                return Result.Err<Script, IEnumerable<RenameError>>(errors.ToImmutableAndFree());
+
+            var visitor = new RenameRewriter(this, variable, newName);
+            var finalTrees = SyntaxTrees;
+            foreach (var tree in trees)
+            {
+                var root = tree.GetRoot();
+                var rewrittenTree = tree.WithRootAndOptions(visitor.Visit(root), tree.Options);
+                finalTrees = finalTrees.Replace(tree, rewrittenTree);
+            }
+            return Result.Ok<Script, IEnumerable<RenameError>>(new Script(finalTrees));
+
+            void handleLocation(SyntaxNode location)
+            {
+                trees.Add(location.SyntaxTree);
+                if (FindScope(location)?.FindVariable(newName) is not null)
+                {
+                    errors.Add(new VariableConflictError(variable));
+                }
+            }
         }
     }
 }

--- a/src/Compilers/Lua/Test/Syntax/Scoping/CanBeAccessedInTests.cs
+++ b/src/Compilers/Lua/Test/Syntax/Scoping/CanBeAccessedInTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Xunit;
+﻿using Xunit;
 
 namespace Loretta.CodeAnalysis.Lua.Syntax.UnitTests.Scoping
 {

--- a/src/Compilers/Lua/Test/Syntax/Scoping/CanBeAccessedInTests.cs
+++ b/src/Compilers/Lua/Test/Syntax/Scoping/CanBeAccessedInTests.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Loretta.CodeAnalysis.Lua.Syntax.UnitTests.Scoping
+{
+    public class CanBeAccessedInTests : ScriptTestsBase
+    {
+        [Fact]
+        [Trait("Category", "Script/CanBeAccessedIn")]
+        public void Script_CanBeAccessedIn_ReturnsTrueWhenSameScope()
+        {
+            var (tree, script) = ParseScript("local a = 1 print(a)");
+            var root = Assert.IsType<CompilationUnitSyntax>(tree.GetRoot());
+            var assignment = Assert.IsType<LocalVariableDeclarationStatementSyntax>(root.Statements.Statements[0]);
+            var name = Assert.IsType<IdentifierNameSyntax>(assignment.Names[0]);
+
+            var variable = script.GetVariable(name);
+
+            Assert.NotNull(variable);
+            Assert.True(variable!.CanBeAccessedIn(variable.ContainingScope));
+        }
+
+        [Fact]
+        [Trait("Category", "Script/CanBeAccessedIn")]
+        public void Script_CanBeAccessedIn_ReturnsTrueWhenScopeIsChild()
+        {
+            var (tree, script) = ParseScript("local a = 1\r\n" +
+                                             "do\r\n" +
+                                             "    print(a)\r\n" +
+                                             "end");
+            var root = Assert.IsType<CompilationUnitSyntax>(tree.GetRoot());
+            var assignment = Assert.IsType<LocalVariableDeclarationStatementSyntax>(root.Statements.Statements[0]);
+            var name = Assert.IsType<IdentifierNameSyntax>(assignment.Names[0]);
+            var doStatement = Assert.IsType<DoStatementSyntax>(root.Statements.Statements[1]);
+
+            var variable = script.GetVariable(name);
+            var doScope = script.GetScope(doStatement);
+
+            Assert.NotNull(variable);
+            Assert.NotNull(doScope);
+            Assert.True(variable!.CanBeAccessedIn(doScope!));
+        }
+
+        [Fact]
+        [Trait("Category", "Script/CanBeAccessedIn")]
+        public void Script_CanBeAccessedIn_ReturnsFalseWhenScopeIsParentOfParent()
+        {
+            var (tree, script) = ParseScript("do\r\n" +
+                                             "    local a = 1\r\n" +
+                                             "end");
+            var root = Assert.IsType<CompilationUnitSyntax>(tree.GetRoot());
+            var doStatement = Assert.IsType<DoStatementSyntax>(root.Statements.Statements[0]);
+            var assignment = Assert.IsType<LocalVariableDeclarationStatementSyntax>(doStatement.Body.Statements[0]);
+            var name = Assert.IsType<IdentifierNameSyntax>(assignment.Names[0]);
+
+            var variable = script.GetVariable(name);
+            var rootScope = script.GetScope(root);
+
+            Assert.NotNull(variable);
+            Assert.NotNull(rootScope);
+            Assert.False(variable!.CanBeAccessedIn(rootScope!));
+        }
+    }
+}

--- a/src/Compilers/Lua/Test/Syntax/Scoping/FindScopeTests.cs
+++ b/src/Compilers/Lua/Test/Syntax/Scoping/FindScopeTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Immutable;
-using System.Linq;
+﻿using System.Linq;
 using Xunit;
 
 namespace Loretta.CodeAnalysis.Lua.Syntax.UnitTests.Scoping

--- a/src/Compilers/Lua/Test/Syntax/Scoping/FindScopeTests.cs
+++ b/src/Compilers/Lua/Test/Syntax/Scoping/FindScopeTests.cs
@@ -7,6 +7,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.UnitTests.Scoping
     public class ScopeTests : ScriptTestsBase
     {
         [Fact]
+        [Trait("Category", "Script/FindScope")]
         public void CompilationUnit_HasFileScope()
         {
             var (tree, script) = ParseScript("print 'Hello'");
@@ -20,6 +21,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.UnitTests.Scoping
         }
 
         [Fact]
+        [Trait("Category", "Script/FindScope")]
         public void FindScope_OnRootElement_ReturnsRootScope()
         {
             var (tree, script) = ParseScript("print 'Hello'");

--- a/src/Compilers/Lua/Test/Syntax/Scoping/FindScopeTests.cs
+++ b/src/Compilers/Lua/Test/Syntax/Scoping/FindScopeTests.cs
@@ -4,15 +4,8 @@ using Xunit;
 
 namespace Loretta.CodeAnalysis.Lua.Syntax.UnitTests.Scoping
 {
-    public class ScopeTests
+    public class ScopeTests : ScriptTestsBase
     {
-        private static (SyntaxTree, Script) ParseScript(string code)
-        {
-            var tree = LuaSyntaxTree.ParseText("print 'Hello'");
-            var script = new Script(ImmutableArray.Create(tree));
-            return (tree, script);
-        }
-
         [Fact]
         public void CompilationUnit_HasFileScope()
         {
@@ -22,8 +15,8 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.UnitTests.Scoping
             var compilationUnitScope = script.GetScope(compilationUnit);
 
             Assert.NotNull(compilationUnitScope);
-            Assert.Equal(ScopeKind.File, compilationUnitScope.Kind);
-            Assert.Equal(script.RootScope, compilationUnitScope.Parent);
+            Assert.Equal(ScopeKind.File, compilationUnitScope!.Kind);
+            Assert.Equal(script.RootScope, compilationUnitScope.ContainingScope);
         }
 
         [Fact]

--- a/src/Compilers/Lua/Test/Syntax/Scoping/FindVariableTests.cs
+++ b/src/Compilers/Lua/Test/Syntax/Scoping/FindVariableTests.cs
@@ -12,7 +12,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.UnitTests.Scoping
         [InlineData(ScopeKind.Block, "b")]
         public void Script_FindVariable_ReturnsNullWhenNoVariableIsAvailable(ScopeKind scopeKind, string name)
         {
-            SetupScript(out _, out var innerMostScope);
+            SetupScript(out var innerMostScope);
             Assert.Null(innerMostScope.FindVariable(name, scopeKind));
         }
 
@@ -30,20 +30,20 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.UnitTests.Scoping
         [InlineData(ScopeKind.Block, "c")]
         public void Script_FindVariable_ReturnsVariableWhenVariableIsAvailable(ScopeKind scopeKind, string name)
         {
-            SetupScript(out _, out var innerMostScope);
+            SetupScript(out var innerMostScope);
             Assert.NotNull(innerMostScope.FindVariable(name, scopeKind));
         }
 
-        private static void SetupScript(out Script script, out IScope innerMostScope)
+        private static void SetupScript(out IScope innerMostScope)
         {
-            script = ParseScript("local a = 1\r\n" +
-                                 "function f(b)\r\n" +
-                                 "    print(b)\r\n" +
-                                 "    do\r\n" +
-                                 "        local c = 3\r\n" +
-                                 "    end\r\n" +
-                                 "end",
-                                 "glob = 2");
+            var script = ParseScript("local a = 1\r\n" +
+                                     "function f(b)\r\n" +
+                                     "    print(b)\r\n" +
+                                     "    do\r\n" +
+                                     "        local c = 3\r\n" +
+                                     "    end\r\n" +
+                                     "end",
+                                     "glob = 2");
 
             var firstTree = script.SyntaxTrees.First();
             var root = Assert.IsType<CompilationUnitSyntax>(firstTree.GetRoot());

--- a/src/Compilers/Lua/Test/Syntax/Scoping/FindVariableTests.cs
+++ b/src/Compilers/Lua/Test/Syntax/Scoping/FindVariableTests.cs
@@ -1,0 +1,56 @@
+﻿using System.Linq;
+using Xunit;
+
+namespace Loretta.CodeAnalysis.Lua.Syntax.UnitTests.Scoping
+{
+    public class FindVariableTests : ScriptTestsBase
+    {
+        [Theory]
+        [Trait("Category", "Script/FindVariable")]
+        [InlineData(ScopeKind.File, "glob")]
+        [InlineData(ScopeKind.Function, "a")]
+        [InlineData(ScopeKind.Block, "b")]
+        public void Script_FindVariable_ReturnsNullWhenNoVariableIsAvailable(ScopeKind scopeKind, string name)
+        {
+            SetupScript(out _, out var innerMostScope);
+            Assert.Null(innerMostScope.FindVariable(name, scopeKind));
+        }
+
+        [Theory]
+        [Trait("Category", "Script/FindVariable")]
+        [InlineData(ScopeKind.Global, "glob")]
+        [InlineData(ScopeKind.Global, "a")]
+        [InlineData(ScopeKind.File, "a")]
+        [InlineData(ScopeKind.Global, "b")]
+        [InlineData(ScopeKind.File, "b")]
+        [InlineData(ScopeKind.Function, "b")]
+        [InlineData(ScopeKind.Global, "c")]
+        [InlineData(ScopeKind.File, "c")]
+        [InlineData(ScopeKind.Function, "c")]
+        [InlineData(ScopeKind.Block, "c")]
+        public void Script_FindVariable_ReturnsVariableWhenVariableIsAvailable(ScopeKind scopeKind, string name)
+        {
+            SetupScript(out _, out var innerMostScope);
+            Assert.NotNull(innerMostScope.FindVariable(name, scopeKind));
+        }
+
+        private static void SetupScript(out Script script, out IScope innerMostScope)
+        {
+            script = ParseScript("local a = 1\r\n" +
+                                 "function f(b)\r\n" +
+                                 "    print(b)\r\n" +
+                                 "    do\r\n" +
+                                 "        local c = 3\r\n" +
+                                 "    end\r\n" +
+                                 "end",
+                                 "glob = 2");
+
+            var firstTree = script.SyntaxTrees.First();
+            var root = Assert.IsType<CompilationUnitSyntax>(firstTree.GetRoot());
+            var functionDecl = Assert.IsType<FunctionDeclarationStatementSyntax>(root.Statements.Statements[1]);
+            var doStatement = Assert.IsType<DoStatementSyntax>(functionDecl.Body.Statements[1]);
+            innerMostScope = script.GetScope(doStatement)!;
+            Assert.NotNull(innerMostScope);
+        }
+    }
+}

--- a/src/Compilers/Lua/Test/Syntax/Scoping/RenameVariableTests.cs
+++ b/src/Compilers/Lua/Test/Syntax/Scoping/RenameVariableTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Loretta.CodeAnalysis.Lua.Syntax.UnitTests.Scoping
+{
+    public class RenameVariableTests : ScriptTestsBase
+    {
+        [Fact]
+        [Trait("Category", "Script/RenameVariable")]
+        public void Script_RenameVariable_ReturnsErrorForUnsupportedIdentifier()
+        {
+            var (tree, script) = ParseScript("local a = 2", LuaSyntaxOptions.Lua51);
+
+            var variable = script.GetVariable(tree.GetRoot().ChildNodes().First().ChildNodes().First().ChildNodes().First());
+            Assert.NotNull(variable);
+            var result = script.RenameVariable(variable!, "\uFEFF");
+            Assert.True(result.IsErr);
+            var error = Assert.IsType<IdentifierNameNotSupportedError>(Assert.Single(result.Err.Value));
+            Assert.Equal(tree, error.TreeWithoutSupport);
+        }
+
+        [Fact]
+        [Trait("Category", "Script/RenameVariable")]
+        public void Script_RenameVariable_ReturnsErrorForConflictingVariable()
+        {
+            var (tree, script) = ParseScript("local a, b = 2, 3", LuaSyntaxOptions.Lua51);
+
+            var localDecl = tree.GetRoot().ChildNodes().First().ChildNodes().First();
+            var variableA = script.GetVariable(localDecl.ChildNodes().First());
+            var variableB = script.GetVariable(localDecl.ChildNodes().ElementAt(1));
+            Assert.NotNull(variableA);
+            Assert.NotNull(variableB);
+            var result = script.RenameVariable(variableA!, "b");
+            Assert.True(result.IsErr);
+            var error = Assert.IsType<VariableConflictError>(Assert.Single(result.Err.Value));
+            Assert.Equal(variableB, error.VariableBeingConflictedWith);
+        }
+
+        [Fact]
+        [Trait("Category", "Script/RenameVariable")]
+        public void Script_RenameVariable_ReturnsCorrectlyRenamedScript()
+        {
+            var (tree, script) = ParseScript("local a = 2\r\nlocal function a() end", LuaSyntaxOptions.Lua51);
+
+            var variable = script.GetVariable(tree.GetRoot().ChildNodes().First().ChildNodes().First().ChildNodes().First());
+            Assert.NotNull(variable);
+            var result = script.RenameVariable(variable!, "b");
+            Assert.True(result.IsOk);
+            var newTree = result.Ok.Value;
+            Assert.Equal("local b = 2\r\nlocal function a() end", Assert.Single(newTree.SyntaxTrees).ToString());
+        }
+    }
+}

--- a/src/Compilers/Lua/Test/Syntax/Scoping/RenameVariableTests.cs
+++ b/src/Compilers/Lua/Test/Syntax/Scoping/RenameVariableTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Linq;
 using Xunit;
 
 namespace Loretta.CodeAnalysis.Lua.Syntax.UnitTests.Scoping

--- a/src/Compilers/Lua/Test/Syntax/Scoping/ScriptTestsBase.cs
+++ b/src/Compilers/Lua/Test/Syntax/Scoping/ScriptTestsBase.cs
@@ -25,6 +25,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.UnitTests.Scoping
             {
                 var tree = ParseWithRoundTripCheck(code, parseOptions);
                 tree.GetDiagnostics().Verify();
+                trees.Add(tree);
             }
             var script = new Script(ImmutableArray.CreateRange(trees));
             return script;

--- a/src/Compilers/Lua/Test/Syntax/Scoping/ScriptTestsBase.cs
+++ b/src/Compilers/Lua/Test/Syntax/Scoping/ScriptTestsBase.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Loretta.CodeAnalysis.Lua.Test.Utilities;

--- a/src/Compilers/Lua/Test/Syntax/Scoping/ScriptTestsBase.cs
+++ b/src/Compilers/Lua/Test/Syntax/Scoping/ScriptTestsBase.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Immutable;
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 using Xunit;
 
 namespace Loretta.CodeAnalysis.Lua.Syntax.UnitTests.Scoping
@@ -11,6 +14,29 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.UnitTests.Scoping
             Assert.Empty(tree.GetDiagnostics());
             var script = new Script(ImmutableArray.Create(tree));
             return (tree, script);
+        }
+
+        protected static Script ParseScript(params string[] codes)
+        {
+            var idx = 0;
+            var trees = Array.ConvertAll(codes, (code) => LuaSyntaxTree.ParseText(code, path: $"codes_{idx++}"));
+            if (trees.Any(t => t.GetDiagnostics().Any()))
+            {
+                foreach (var tree in trees)
+                {
+                    if (tree.GetDiagnostics().Any())
+                    {
+                        Console.WriteLine(tree.FilePath + ":");
+                        foreach (var diagnostic in tree.GetDiagnostics())
+                        {
+                            Console.WriteLine(diagnostic);
+                        }
+                    }
+                }
+            }
+            Assert.Empty(trees.SelectMany(tree => tree.GetDiagnostics()));
+            var script = new Script(ImmutableArray.CreateRange(trees));
+            return script;
         }
     }
 }

--- a/src/Compilers/Lua/Test/Syntax/Scoping/ScriptTestsBase.cs
+++ b/src/Compilers/Lua/Test/Syntax/Scoping/ScriptTestsBase.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Immutable;
+using Xunit;
+
+namespace Loretta.CodeAnalysis.Lua.Syntax.UnitTests.Scoping
+{
+    public class ScriptTestsBase
+    {
+        protected static (SyntaxTree, Script) ParseScript(string code)
+        {
+            var tree = LuaSyntaxTree.ParseText(code);
+            Assert.Empty(tree.GetDiagnostics());
+            var script = new Script(ImmutableArray.Create(tree));
+            return (tree, script);
+        }
+    }
+}

--- a/src/Compilers/Lua/Test/Syntax/Scoping/ScriptTestsBase.cs
+++ b/src/Compilers/Lua/Test/Syntax/Scoping/ScriptTestsBase.cs
@@ -1,8 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using Loretta.CodeAnalysis.Lua.Test.Utilities;
-using Xunit;
 
 namespace Loretta.CodeAnalysis.Lua.Syntax.UnitTests.Scoping
 {
@@ -21,13 +19,13 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.UnitTests.Scoping
 
         protected static Script ParseScript(LuaSyntaxOptions options, params string[] codes)
         {
+            var parseOptions = new LuaParseOptions(options);
             var trees = new List<SyntaxTree>();
             foreach (var code in codes)
             {
-                var tree = ParseWithRoundTripCheck(code);
+                var tree = ParseWithRoundTripCheck(code, parseOptions);
                 tree.GetDiagnostics().Verify();
             }
-            Assert.Empty(trees.SelectMany(tree => tree.GetDiagnostics()));
             var script = new Script(ImmutableArray.CreateRange(trees));
             return script;
         }


### PR DESCRIPTION
### Added
- Added `IScope.ContainedScopes` which lets you check scopes contained within another scope.
- Added `IVariable.CanBeAccessedIn(IScope)` which lets you check if the variable can be accessed within a given scope.
- Added `IScope.FindVariable(string)` which lets you try to find a variable in a scope or any of its parents.
- Added `Script.RenameVariable(IVariable variable, string newName)` which lets you rename a variable in a new script instance.

### Changed
- Renamed `IScope.Parent` to `IScope.ContainingScope` to be more consistent with `ContainedScopes`.