### PR TITLE
Implement local variable attributes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,9 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Added support for string length to the constant folder.
+- The following were added as a part of implementing local variable attributes:
+	- `Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax`;
+	- `SyntaxKind.LocalDeclarationName`;
+	- `SyntaxFactory.LocalDeclarationName`;
+	- `LuaSyntaxVisitor.VisitLocalDeclarationName`;
+	- `LuaSyntaxVisitor<TResult>.VisitLocalDeclarationName`;
+	- `LuaSyntaxRewriter.VisitLocalDeclarationName`;
+	- `Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax`;
+	- `SyntaxKind.VariableAttribute`;
+	- `SyntaxFactory.VariableAttribute`;
+	- `LuaSyntaxVisitor.VisitVariableAttribute`;
+	- `LuaSyntaxVisitor<TResult>.VisitVariableAttribute`.
+	- `LuaSyntaxRewriter.VisitVariableAttribute`;
 
 ### Changed
 - Constant folder now attempts to preserve trivia around nodes that were folded.
+- [Breaking] The following were changed as a result of implementing local variable attributes:
+	- `LocalVariableDeclarationStatementSyntax.Names` now returns a `SeparatedSyntaxList<LocalDeclarationNameSyntax>` instead of `SeparatedSyntaxList<IdentifierNameSyntax>`;
+	- `LocalVariableDeclarationStatementSyntax.Update` now receives a `SeparatedSyntaxList<LocalDeclarationNameSyntax>` instead of `SeparatedSyntaxList<IdentifierNameSyntax>`;
+	- `LocalVariableDeclarationStatementSyntax.AddNames` now receives a `params LocalDeclarationNameSyntax[]` instead of `params IdentifierNameSyntax[]`;
+	- `LocalVariableDeclarationStatementSyntax.WithNames` now receives a `SeparatedSyntaxList<LocalDeclarationNameSyntax>` instead of `SeparatedSyntaxList<IdentifierNameSyntax>`;
+	- `SyntaxFactory.LocalVariableDeclarationStatement` overloads now receive a `SeparatedSyntaxList<LocalDeclarationNameSyntax>` instead of `SeparatedSyntaxList<IdentifierNameSyntax>`.
 
 ## v0.2.7-beta.13
 ### Fixed

--- a/src/Compilers/Lua/Portable/LuaSyntaxOptions.cs
+++ b/src/Compilers/Lua/Portable/LuaSyntaxOptions.cs
@@ -35,7 +35,8 @@ namespace Loretta.CodeAnalysis.Lua
             continueType: ContinueType.None,
             acceptIfExpression: true,
             acceptHashStrings: false,
-            acceptInvalidEscapes: true);
+            acceptInvalidEscapes: true,
+            acceptLocalVariableAttributes: false);
 
         /// <summary>
         /// The Lua 5.2 preset.
@@ -54,6 +55,12 @@ namespace Loretta.CodeAnalysis.Lua
         public static readonly LuaSyntaxOptions Lua53 = Lua52.With(
             acceptBitwiseOperators: true,
             acceptUnicodeEscape: true);
+
+        /// <summary>
+        /// The Lua 5.4 preset.
+        /// </summary>
+        public static readonly LuaSyntaxOptions Lua54 = Lua53.With(
+            acceptLocalVariableAttributes: true);
 
         /// <summary>
         /// The LuaJIT 2.0 preset.
@@ -77,7 +84,8 @@ namespace Loretta.CodeAnalysis.Lua
             continueType: ContinueType.None,
             acceptIfExpression: false,
             acceptHashStrings: false,
-            acceptInvalidEscapes: false);
+            acceptInvalidEscapes: false,
+            acceptLocalVariableAttributes: false);
 
         /// <summary>
         /// The LuaJIT 2.1-beta3 preset.
@@ -116,7 +124,8 @@ namespace Loretta.CodeAnalysis.Lua
             continueType: ContinueType.ContextualKeyword,
             acceptIfExpression: true,
             acceptHashStrings: false,
-            acceptInvalidEscapes: true);
+            acceptInvalidEscapes: true,
+            acceptLocalVariableAttributes: false);
 
         /// <summary>
         /// The FiveM preset.
@@ -147,7 +156,8 @@ namespace Loretta.CodeAnalysis.Lua
             continueType: ContinueType.ContextualKeyword,
             acceptIfExpression: true,
             acceptHashStrings: true,
-            acceptInvalidEscapes: false);
+            acceptInvalidEscapes: false,
+            acceptLocalVariableAttributes: true);
 
         /// <summary>
         /// All presets that are preconfigured in <see cref="LuaSyntaxOptions"/>.
@@ -157,10 +167,12 @@ namespace Loretta.CodeAnalysis.Lua
             Lua51,
             Lua52,
             Lua53,
+            Lua54,
             LuaJIT20,
             LuaJIT21,
             GMod,
             Roblox,
+            FiveM,
             All
         });
 
@@ -186,6 +198,7 @@ namespace Loretta.CodeAnalysis.Lua
         /// <param name="acceptIfExpression"><inheritdoc cref="AcceptIfExpressions" path="/summary" /></param>
         /// <param name="acceptHashStrings"><inheritdoc cref="AcceptHashStrings" path="/summary" /></param>
         /// <param name="acceptInvalidEscapes"><inheritdoc cref="AcceptInvalidEscapes" path="/summary" /></param>
+        /// <param name="acceptLocalVariableAttributes"><inheritdoc cref="AcceptLocalVariableAttributes" path="/summary" /></param>
         public LuaSyntaxOptions(
             bool acceptBinaryNumbers,
             bool acceptCCommentSyntax,
@@ -205,7 +218,8 @@ namespace Loretta.CodeAnalysis.Lua
             ContinueType continueType,
             bool acceptIfExpression,
             bool acceptHashStrings,
-            bool acceptInvalidEscapes)
+            bool acceptInvalidEscapes,
+            bool acceptLocalVariableAttributes)
         {
             AcceptBinaryNumbers = acceptBinaryNumbers;
             AcceptCCommentSyntax = acceptCCommentSyntax;
@@ -226,6 +240,7 @@ namespace Loretta.CodeAnalysis.Lua
             AcceptIfExpressions = acceptIfExpression;
             AcceptHashStrings = acceptHashStrings;
             AcceptInvalidEscapes = acceptInvalidEscapes;
+            AcceptLocalVariableAttributes = acceptLocalVariableAttributes;
         }
 
         /// <summary>
@@ -332,6 +347,11 @@ namespace Loretta.CodeAnalysis.Lua
         public bool AcceptInvalidEscapes { get; }
 
         /// <summary>
+        /// Whether to accept Lua 5.4 variable attributes.
+        /// </summary>
+        public bool AcceptLocalVariableAttributes { get; }
+
+        /// <summary>
         /// Creates a new lua options changing the provided fields.
         /// </summary>
         /// <param name="acceptBinaryNumbers">
@@ -410,6 +430,10 @@ namespace Loretta.CodeAnalysis.Lua
         /// <inheritdoc cref="AcceptInvalidEscapes" path="/summary" /> If None uses the value of
         /// <see cref="AcceptInvalidEscapes" />.
         /// </param>
+        /// <param name="acceptLocalVariableAttributes">
+        /// <inheritdoc cref="AcceptLocalVariableAttributes" path="/summary" /> If None uses the
+        /// value of <see cref="AcceptLocalVariableAttributes"/>.
+        /// </param>
         /// <returns></returns>
         public LuaSyntaxOptions With(
             Option<bool> acceptBinaryNumbers = default,
@@ -430,7 +454,8 @@ namespace Loretta.CodeAnalysis.Lua
             Option<ContinueType> continueType = default,
             Option<bool> acceptIfExpression = default,
             Option<bool> acceptHashStrings = default,
-            Option<bool> acceptInvalidEscapes = default) =>
+            Option<bool> acceptInvalidEscapes = default,
+            Option<bool> acceptLocalVariableAttributes = default) =>
             new(
                 acceptBinaryNumbers.UnwrapOr(AcceptBinaryNumbers),
                 acceptCCommentSyntax.UnwrapOr(AcceptCCommentSyntax),
@@ -450,7 +475,8 @@ namespace Loretta.CodeAnalysis.Lua
                 continueType.UnwrapOr(ContinueType),
                 acceptIfExpression.UnwrapOr(AcceptIfExpressions),
                 acceptHashStrings.UnwrapOr(AcceptHashStrings),
-                acceptInvalidEscapes.UnwrapOr(AcceptInvalidEscapes));
+                acceptInvalidEscapes.UnwrapOr(AcceptInvalidEscapes),
+                acceptLocalVariableAttributes.UnwrapOr(AcceptLocalVariableAttributes));
 
         /// <inheritdoc/>
         public override bool Equals(object? obj) =>
@@ -476,7 +502,8 @@ namespace Loretta.CodeAnalysis.Lua
                 && AcceptWhitespaceEscape == other.AcceptWhitespaceEscape
                 && ContinueType == other.ContinueType
                 && AcceptIfExpressions == other.AcceptIfExpressions
-                && AcceptHashStrings == other.AcceptHashStrings);
+                && AcceptHashStrings == other.AcceptHashStrings
+                && AcceptLocalVariableAttributes == other.AcceptLocalVariableAttributes);
 
         /// <inheritdoc/>
         public override int GetHashCode()
@@ -499,6 +526,7 @@ namespace Loretta.CodeAnalysis.Lua
             hash.Add(ContinueType);
             hash.Add(AcceptIfExpressions);
             hash.Add(AcceptHashStrings);
+            hash.Add(AcceptLocalVariableAttributes);
             return hash.ToHashCode();
         }
 
@@ -539,7 +567,7 @@ namespace Loretta.CodeAnalysis.Lua
             }
             else
             {
-                return $"{{ AcceptBinaryNumbers = {AcceptBinaryNumbers}, AcceptCCommentSyntax = {AcceptCCommentSyntax}, AcceptCompoundAssignment = {AcceptCompoundAssignment}, AcceptEmptyStatements = {AcceptEmptyStatements}, AcceptCBooleanOperators = {AcceptCBooleanOperators}, AcceptGoto = {AcceptGoto}, AcceptHexEscapesInStrings = {AcceptHexEscapesInStrings}, AcceptHexFloatLiterals = {AcceptHexFloatLiterals}, AcceptOctalNumbers = {AcceptOctalNumbers}, AcceptShebang = {AcceptShebang}, AcceptUnderscoreInNumberLiterals = {AcceptUnderscoreInNumberLiterals}, UseLuaJitIdentifierRules = {UseLuaJitIdentifierRules}, AcceptBitwiseOperators = {AcceptBitwiseOperators}, AcceptWhitespaceEscape = {AcceptWhitespaceEscape}, ContinueType = {ContinueType}, AcceptIfExpressions = {AcceptIfExpressions}, AcceptHashStrings ={AcceptHashStrings} }}";
+                return $"{{ AcceptBinaryNumbers = {AcceptBinaryNumbers}, AcceptCCommentSyntax = {AcceptCCommentSyntax}, AcceptCompoundAssignment = {AcceptCompoundAssignment}, AcceptEmptyStatements = {AcceptEmptyStatements}, AcceptCBooleanOperators = {AcceptCBooleanOperators}, AcceptGoto = {AcceptGoto}, AcceptHexEscapesInStrings = {AcceptHexEscapesInStrings}, AcceptHexFloatLiterals = {AcceptHexFloatLiterals}, AcceptOctalNumbers = {AcceptOctalNumbers}, AcceptShebang = {AcceptShebang}, AcceptUnderscoreInNumberLiterals = {AcceptUnderscoreInNumberLiterals}, UseLuaJitIdentifierRules = {UseLuaJitIdentifierRules}, AcceptBitwiseOperators = {AcceptBitwiseOperators}, AcceptWhitespaceEscape = {AcceptWhitespaceEscape}, ContinueType = {ContinueType}, AcceptIfExpressions = {AcceptIfExpressions}, AcceptHashStrings = {AcceptHashStrings}, AcceptLocalVariableAttributes = {AcceptLocalVariableAttributes} }}";
             }
         }
 

--- a/src/Compilers/Lua/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/Lua/Portable/Parser/LanguageParser.cs
@@ -213,13 +213,30 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
             }
         }
 
+        private LocalDeclarationNameSyntax ParseLocalDeclarationName()
+        {
+            var name = ParseIdentifierName();
+
+            VariableAttributeSyntax? attribute = null;
+            if (CurrentToken.Kind is SyntaxKind.LessThanToken)
+            {
+                var lessThanToken = EatToken(SyntaxKind.LessThanToken);
+                var identifierName = EatToken(SyntaxKind.IdentifierToken);
+                var greaterThanToken = EatToken(SyntaxKind.GreaterThanToken);
+
+                attribute = SyntaxFactory.VariableAttribute(lessThanToken, identifierName, greaterThanToken);
+            }
+
+            return SyntaxFactory.LocalDeclarationName(name, attribute);
+        }
+
         private LocalVariableDeclarationStatementSyntax ParseLocalVariableDeclarationStatement()
         {
             var localKeyword = EatToken(SyntaxKind.LocalKeyword);
             var namesAndSeparatorsBuilder =
-                _pool.AllocateSeparated<IdentifierNameSyntax>();
+                _pool.AllocateSeparated<LocalDeclarationNameSyntax>();
 
-            var name = ParseIdentifierName();
+            var name = ParseLocalDeclarationName();
             namesAndSeparatorsBuilder.Add(name);
 
             while (CurrentToken.Kind is SyntaxKind.CommaToken)
@@ -227,7 +244,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                 var separator = EatToken(SyntaxKind.CommaToken);
                 namesAndSeparatorsBuilder.AddSeparator(separator);
 
-                name = ParseIdentifierName();
+                name = ParseLocalDeclarationName();
                 namesAndSeparatorsBuilder.Add(name);
             }
 

--- a/src/Compilers/Lua/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Lua/Portable/PublicAPI.Unshipped.txt
@@ -1,1 +1,53 @@
 ﻿#nullable enable
+*REMOVED*Loretta.CodeAnalysis.Lua.Syntax.LocalVariableDeclarationStatementSyntax.AddNames(params Loretta.CodeAnalysis.Lua.Syntax.IdentifierNameSyntax![]! items) -> Loretta.CodeAnalysis.Lua.Syntax.LocalVariableDeclarationStatementSyntax!
+*REMOVED*Loretta.CodeAnalysis.Lua.Syntax.LocalVariableDeclarationStatementSyntax.Names.get -> Loretta.CodeAnalysis.SeparatedSyntaxList<Loretta.CodeAnalysis.Lua.Syntax.IdentifierNameSyntax!>
+*REMOVED*Loretta.CodeAnalysis.Lua.Syntax.LocalVariableDeclarationStatementSyntax.Update(Loretta.CodeAnalysis.SyntaxToken localKeyword, Loretta.CodeAnalysis.SeparatedSyntaxList<Loretta.CodeAnalysis.Lua.Syntax.IdentifierNameSyntax!> names, Loretta.CodeAnalysis.Lua.Syntax.EqualsValuesClauseSyntax? equalsValues, Loretta.CodeAnalysis.SyntaxToken semicolonToken) -> Loretta.CodeAnalysis.Lua.Syntax.LocalVariableDeclarationStatementSyntax!
+*REMOVED*Loretta.CodeAnalysis.Lua.Syntax.LocalVariableDeclarationStatementSyntax.WithNames(Loretta.CodeAnalysis.SeparatedSyntaxList<Loretta.CodeAnalysis.Lua.Syntax.IdentifierNameSyntax!> names) -> Loretta.CodeAnalysis.Lua.Syntax.LocalVariableDeclarationStatementSyntax!
+*REMOVED*static Loretta.CodeAnalysis.Lua.SyntaxFactory.LocalVariableDeclarationStatement(Loretta.CodeAnalysis.SeparatedSyntaxList<Loretta.CodeAnalysis.Lua.Syntax.IdentifierNameSyntax!> names, Loretta.CodeAnalysis.Lua.Syntax.EqualsValuesClauseSyntax? equalsValues) -> Loretta.CodeAnalysis.Lua.Syntax.LocalVariableDeclarationStatementSyntax!
+*REMOVED*static Loretta.CodeAnalysis.Lua.SyntaxFactory.LocalVariableDeclarationStatement(Loretta.CodeAnalysis.SeparatedSyntaxList<Loretta.CodeAnalysis.Lua.Syntax.IdentifierNameSyntax!> names, Loretta.CodeAnalysis.SeparatedSyntaxList<Loretta.CodeAnalysis.Lua.Syntax.ExpressionSyntax!> values) -> Loretta.CodeAnalysis.Lua.Syntax.LocalVariableDeclarationStatementSyntax!
+*REMOVED*static Loretta.CodeAnalysis.Lua.SyntaxFactory.LocalVariableDeclarationStatement(Loretta.CodeAnalysis.SeparatedSyntaxList<Loretta.CodeAnalysis.Lua.Syntax.IdentifierNameSyntax!> names) -> Loretta.CodeAnalysis.Lua.Syntax.LocalVariableDeclarationStatementSyntax!
+*REMOVED*static Loretta.CodeAnalysis.Lua.SyntaxFactory.LocalVariableDeclarationStatement(Loretta.CodeAnalysis.SyntaxToken localKeyword, Loretta.CodeAnalysis.SeparatedSyntaxList<Loretta.CodeAnalysis.Lua.Syntax.IdentifierNameSyntax!> names, Loretta.CodeAnalysis.Lua.Syntax.EqualsValuesClauseSyntax? equalsValues, Loretta.CodeAnalysis.SyntaxToken semicolonToken) -> Loretta.CodeAnalysis.Lua.Syntax.LocalVariableDeclarationStatementSyntax!
+Loretta.CodeAnalysis.Lua.LuaSyntaxOptions.AcceptLocalVariableAttributes.get -> bool
+Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax
+Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax.Attribute.get -> Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax?
+Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax.AttributeName.get -> string?
+Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax.IdentifierName.get -> Loretta.CodeAnalysis.Lua.Syntax.IdentifierNameSyntax!
+Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax.Name.get -> string!
+Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax.Update(Loretta.CodeAnalysis.Lua.Syntax.IdentifierNameSyntax! identifierName, Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax? attribute) -> Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax!
+Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax.WithAttribute(Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax? attribute) -> Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax!
+Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax.WithIdentifierName(Loretta.CodeAnalysis.Lua.Syntax.IdentifierNameSyntax! identifierName) -> Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax!
+Loretta.CodeAnalysis.Lua.Syntax.LocalVariableDeclarationStatementSyntax.AddNames(params Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax![]! items) -> Loretta.CodeAnalysis.Lua.Syntax.LocalVariableDeclarationStatementSyntax!
+Loretta.CodeAnalysis.Lua.Syntax.LocalVariableDeclarationStatementSyntax.Names.get -> Loretta.CodeAnalysis.SeparatedSyntaxList<Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax!>
+Loretta.CodeAnalysis.Lua.Syntax.LocalVariableDeclarationStatementSyntax.Update(Loretta.CodeAnalysis.SyntaxToken localKeyword, Loretta.CodeAnalysis.SeparatedSyntaxList<Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax!> names, Loretta.CodeAnalysis.Lua.Syntax.EqualsValuesClauseSyntax? equalsValues, Loretta.CodeAnalysis.SyntaxToken semicolonToken) -> Loretta.CodeAnalysis.Lua.Syntax.LocalVariableDeclarationStatementSyntax!
+Loretta.CodeAnalysis.Lua.Syntax.LocalVariableDeclarationStatementSyntax.WithNames(Loretta.CodeAnalysis.SeparatedSyntaxList<Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax!> names) -> Loretta.CodeAnalysis.Lua.Syntax.LocalVariableDeclarationStatementSyntax!
+Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax
+Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax.GreaterThanToken.get -> Loretta.CodeAnalysis.SyntaxToken
+Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax.Identifier.get -> Loretta.CodeAnalysis.SyntaxToken
+Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax.LessThanToken.get -> Loretta.CodeAnalysis.SyntaxToken
+Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax.Name.get -> string!
+Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax.Update(Loretta.CodeAnalysis.SyntaxToken lessThanToken, Loretta.CodeAnalysis.SyntaxToken identifier, Loretta.CodeAnalysis.SyntaxToken greaterThanToken) -> Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax!
+Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax.WithGreaterThanToken(Loretta.CodeAnalysis.SyntaxToken greaterThanToken) -> Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax!
+Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax.WithIdentifier(Loretta.CodeAnalysis.SyntaxToken identifier) -> Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax!
+Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax.WithLessThanToken(Loretta.CodeAnalysis.SyntaxToken lessThanToken) -> Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax!
+Loretta.CodeAnalysis.Lua.SyntaxKind.LocalDeclarationName = 2085 -> Loretta.CodeAnalysis.Lua.SyntaxKind
+Loretta.CodeAnalysis.Lua.SyntaxKind.VariableAttribute = 2084 -> Loretta.CodeAnalysis.Lua.SyntaxKind
+override Loretta.CodeAnalysis.Lua.LuaSyntaxRewriter.VisitLocalDeclarationName(Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax! node) -> Loretta.CodeAnalysis.SyntaxNode?
+override Loretta.CodeAnalysis.Lua.LuaSyntaxRewriter.VisitVariableAttribute(Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax! node) -> Loretta.CodeAnalysis.SyntaxNode?
+override Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax.Accept(Loretta.CodeAnalysis.Lua.LuaSyntaxVisitor! visitor) -> void
+override Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax.Accept<TResult>(Loretta.CodeAnalysis.Lua.LuaSyntaxVisitor<TResult>! visitor) -> TResult?
+override Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax.Accept(Loretta.CodeAnalysis.Lua.LuaSyntaxVisitor! visitor) -> void
+override Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax.Accept<TResult>(Loretta.CodeAnalysis.Lua.LuaSyntaxVisitor<TResult>! visitor) -> TResult?
+static Loretta.CodeAnalysis.Lua.SyntaxFactory.LocalDeclarationName(Loretta.CodeAnalysis.Lua.Syntax.IdentifierNameSyntax! identifierName, Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax? attribute) -> Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax!
+static Loretta.CodeAnalysis.Lua.SyntaxFactory.LocalDeclarationName(Loretta.CodeAnalysis.Lua.Syntax.IdentifierNameSyntax! identifierName) -> Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax!
+static Loretta.CodeAnalysis.Lua.SyntaxFactory.LocalDeclarationName(string! identifierName) -> Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax!
+static Loretta.CodeAnalysis.Lua.SyntaxFactory.LocalVariableDeclarationStatement(Loretta.CodeAnalysis.SeparatedSyntaxList<Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax!> names, Loretta.CodeAnalysis.Lua.Syntax.EqualsValuesClauseSyntax? equalsValues) -> Loretta.CodeAnalysis.Lua.Syntax.LocalVariableDeclarationStatementSyntax!
+static Loretta.CodeAnalysis.Lua.SyntaxFactory.LocalVariableDeclarationStatement(Loretta.CodeAnalysis.SeparatedSyntaxList<Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax!> names, Loretta.CodeAnalysis.SeparatedSyntaxList<Loretta.CodeAnalysis.Lua.Syntax.ExpressionSyntax!> values) -> Loretta.CodeAnalysis.Lua.Syntax.LocalVariableDeclarationStatementSyntax!
+static Loretta.CodeAnalysis.Lua.SyntaxFactory.LocalVariableDeclarationStatement(Loretta.CodeAnalysis.SeparatedSyntaxList<Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax!> names) -> Loretta.CodeAnalysis.Lua.Syntax.LocalVariableDeclarationStatementSyntax!
+static Loretta.CodeAnalysis.Lua.SyntaxFactory.LocalVariableDeclarationStatement(Loretta.CodeAnalysis.SyntaxToken localKeyword, Loretta.CodeAnalysis.SeparatedSyntaxList<Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax!> names, Loretta.CodeAnalysis.Lua.Syntax.EqualsValuesClauseSyntax? equalsValues, Loretta.CodeAnalysis.SyntaxToken semicolonToken) -> Loretta.CodeAnalysis.Lua.Syntax.LocalVariableDeclarationStatementSyntax!
+static Loretta.CodeAnalysis.Lua.SyntaxFactory.VariableAttribute(Loretta.CodeAnalysis.SyntaxToken identifier) -> Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax!
+static Loretta.CodeAnalysis.Lua.SyntaxFactory.VariableAttribute(Loretta.CodeAnalysis.SyntaxToken lessThanToken, Loretta.CodeAnalysis.SyntaxToken identifier, Loretta.CodeAnalysis.SyntaxToken greaterThanToken) -> Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax!
+static Loretta.CodeAnalysis.Lua.SyntaxFactory.VariableAttribute(string! identifier) -> Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax!
+virtual Loretta.CodeAnalysis.Lua.LuaSyntaxVisitor.VisitLocalDeclarationName(Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax! node) -> void
+virtual Loretta.CodeAnalysis.Lua.LuaSyntaxVisitor.VisitVariableAttribute(Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax! node) -> void
+virtual Loretta.CodeAnalysis.Lua.LuaSyntaxVisitor<TResult>.VisitLocalDeclarationName(Loretta.CodeAnalysis.Lua.Syntax.LocalDeclarationNameSyntax! node) -> TResult?
+virtual Loretta.CodeAnalysis.Lua.LuaSyntaxVisitor<TResult>.VisitVariableAttribute(Loretta.CodeAnalysis.Lua.Syntax.VariableAttributeSyntax! node) -> TResult?

--- a/src/Compilers/Lua/Portable/Script/ScopeAndVariableManager.ScopeAndVariableWalker.cs
+++ b/src/Compilers/Lua/Portable/Script/ScopeAndVariableManager.ScopeAndVariableWalker.cs
@@ -294,11 +294,13 @@ namespace Loretta.CodeAnalysis.Lua
             public override void VisitLocalVariableDeclarationStatement(LocalVariableDeclarationStatementSyntax node)
             {
                 Visit(node.EqualsValues);
-                foreach (var name in node.Names)
+                foreach (var localName in node.Names)
                 {
+                    var name = localName.IdentifierName;
                     if (name.IsMissing || string.IsNullOrWhiteSpace(name.Name))
                         continue;
                     var variable = Scope.CreateVariable(VariableKind.Local, name.Name, node);
+                    _variables.Add(localName, variable);
                     _variables.Add(name, variable);
                     variable.AddWriteLocation(node);
                     variable.AddReferencingScope(Scope);

--- a/src/Compilers/Lua/Portable/Syntax/LocalDeclarationNameSyntax.cs
+++ b/src/Compilers/Lua/Portable/Syntax/LocalDeclarationNameSyntax.cs
@@ -1,0 +1,15 @@
+﻿namespace Loretta.CodeAnalysis.Lua.Syntax
+{
+    public sealed partial class LocalDeclarationNameSyntax
+    {
+        /// <summary>
+        /// The variable name.
+        /// </summary>
+        public string Name => IdentifierName.Name;
+
+        /// <summary>
+        /// The name of the attribute.
+        /// </summary>
+        public string? AttributeName => Attribute?.Name;
+    }
+}

--- a/src/Compilers/Lua/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/Lua/Portable/Syntax/Syntax.xml
@@ -1034,7 +1034,7 @@
       </PropertyComment>
       <Kind Name="LocalKeyword" />
     </Field>
-    <Field Name="Names" Type="SeparatedSyntaxList&lt;IdentifierNameSyntax&gt;" MinCount="1">
+    <Field Name="Names" Type="SeparatedSyntaxList&lt;LocalDeclarationNameSyntax&gt;" MinCount="1">
       <PropertyComment>
         <summary>The list of names being assigned to.</summary>
       </PropertyComment>

--- a/src/Compilers/Lua/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/Lua/Portable/Syntax/Syntax.xml
@@ -857,6 +857,70 @@
 
   <!-- Assignment statement -->
 
+  <Node Name="VariableAttributeSyntax" Base="LuaSyntaxNode">
+    <TypeComment>
+      <summary>Represents a variable attribute syntax.</summary>
+    </TypeComment>
+    <FactoryComment>
+      <summary>
+        Creates a new <see cref="VariableAttributeSyntax" /> node.
+      </summary>
+    </FactoryComment>
+    <Kind Name="VariableAttribute" />
+    <Field Name="LessThanToken" Type="SyntaxToken">
+      <PropertyComment>
+        <summary>
+          The leading <c>&lt;</c> token.
+        </summary>
+      </PropertyComment>
+      <Kind Name="LessThanToken" />
+    </Field>
+    <Field Name="Identifier" Type="SyntaxToken">
+      <PropertyComment>
+        <summary>The attribute name identifier token.</summary>
+      </PropertyComment>
+      <Kind Name="IdentifierToken" />
+    </Field>
+    <Field Name="GreaterThanToken" Type="SyntaxToken">
+      <PropertyComment>
+        <summary>
+          The trailing <c>&gt;</c> token.
+        </summary>
+      </PropertyComment>
+      <Kind Name="GreaterThanToken" />
+    </Field>
+  </Node>
+
+  <Node Name="LocalDeclarationNameSyntax" Base="LuaSyntaxNode">
+    <TypeComment>
+      <summary>
+        Represents a variable name in a <see cref="LocalVariableDeclarationStatementSyntax" /> node.
+      </summary>
+    </TypeComment>
+    <FactoryComment>
+      <summary>
+        Creates a new <see cref="LocalDeclarationNameSyntax" /> node.
+      </summary>
+    </FactoryComment>
+    <Kind Name="LocalDeclarationName" />
+    <Field Name="IdentifierName" Type="IdentifierNameSyntax">
+      <PropertyComment>
+        <summary>
+          The <see cref="IdentifierNameSyntax" /> containing the name.
+        </summary>
+      </PropertyComment>
+      <Kind Name="IdentifierName" />
+    </Field>
+    <Field Name="Attribute" Type="VariableAttributeSyntax" Optional="true">
+      <PropertyComment>
+        <summary>
+          The <see cref="VariableAttributeSyntax" /> containing the (optional) variable attribute.
+        </summary>
+      </PropertyComment>
+      <Kind Name="VariableAttribute" />
+    </Field>
+  </Node>
+
   <Node Name="EqualsValuesClauseSyntax" Base="LuaSyntaxNode">
     <TypeComment>
       <summary>Represents the values being assigned to the names in an assignment or variable declaration.</summary>

--- a/src/Compilers/Lua/Portable/Syntax/SyntaxFactory.cs
+++ b/src/Compilers/Lua/Portable/Syntax/SyntaxFactory.cs
@@ -928,7 +928,7 @@ namespace Loretta.CodeAnalysis.Lua
         /// Creates a new <see cref="LocalVariableDeclarationStatementSyntax"/> node.
         /// </summary>
         public static LocalVariableDeclarationStatementSyntax LocalVariableDeclarationStatement(
-            SeparatedSyntaxList<IdentifierNameSyntax> names,
+            SeparatedSyntaxList<LocalDeclarationNameSyntax> names,
             SeparatedSyntaxList<ExpressionSyntax> values) =>
             LocalVariableDeclarationStatement(names, EqualsValuesClause(values));
     }

--- a/src/Compilers/Lua/Portable/Syntax/SyntaxKind.cs
+++ b/src/Compilers/Lua/Portable/Syntax/SyntaxKind.cs
@@ -524,6 +524,8 @@ namespace Loretta.CodeAnalysis.Lua
         ExpressionListFunctionArgument = 2011,
 
         EqualsValuesClause = 2083,
+        VariableAttribute = 2084,
+        LocalDeclarationName = 2085,
 
         // Primary Expressions
         [ExtraCategories(SyntaxKindCategory.FunctionExpressionOrDeclaration)]
@@ -678,7 +680,7 @@ namespace Loretta.CodeAnalysis.Lua
         StatementList = 2072,
         EmptyStatement = 2073,
 
-        // Big gap 2084-3001 (insert new nodes here)
+        // Big gap 2086-3001 (insert new nodes here)
 
         // Other types of nodes
         CompilationUnit = 3001,

--- a/src/Compilers/Lua/Portable/Syntax/VariableAttributeSyntax.cs
+++ b/src/Compilers/Lua/Portable/Syntax/VariableAttributeSyntax.cs
@@ -1,0 +1,10 @@
+﻿namespace Loretta.CodeAnalysis.Lua.Syntax
+{
+    public sealed partial class VariableAttributeSyntax
+    {
+        /// <summary>
+        /// The name of the attribute.
+        /// </summary>
+        public string Name => Identifier.Text;
+    }
+}

--- a/src/Compilers/Lua/Test/Portable/Lexical/LexicalErrorTests.cs
+++ b/src/Compilers/Lua/Test/Portable/Lexical/LexicalErrorTests.cs
@@ -8,7 +8,7 @@ namespace Loretta.CodeAnalysis.Lua.UnitTests.Lexical
     public class LexicalErrorTests : LuaTestBase
     {
         private static void ParseAndValidate(string text, LuaSyntaxOptions? options = null, params DiagnosticDescription[] expectedErrors) =>
-            ParsingTests.ParseAndValidate(text, options, expectedErrors);
+            ParsingTestsBase.ParseAndValidate(text, options, expectedErrors);
 
         [Fact]
         [Trait("Category", "Lexer/Diagnostics")]

--- a/src/Compilers/Lua/Test/Portable/Loretta.CodeAnalysis.Lua.UnitTests.csproj
+++ b/src/Compilers/Lua/Test/Portable/Loretta.CodeAnalysis.Lua.UnitTests.csproj
@@ -34,8 +34,4 @@
     <ProjectReference Include="..\Utilities\Loretta.CodeAnalysis.Lua.Test.Utilities.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Parsing\" />
-  </ItemGroup>
-
 </Project>

--- a/src/Compilers/Lua/Test/Portable/Parsing/LocalVariableAttributeTests.cs
+++ b/src/Compilers/Lua/Test/Portable/Parsing/LocalVariableAttributeTests.cs
@@ -1,0 +1,391 @@
+﻿using Loretta.CodeAnalysis.Lua.Test.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Loretta.CodeAnalysis.Lua.UnitTests.Parsing
+{
+    public class LocalVariableAttributeTests : ParsingTestsBase
+    {
+        public LocalVariableAttributeTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void Parser_GeneratesAnErrorDiagnosticWhen_IdentifierIsMissing()
+        {
+            UsingStatement(
+                "local a <>",
+                // (1,10): error LUA1001: Identifier expected
+                // local a <>
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, ">").WithLocation(1, 10));
+
+            N(SyntaxKind.LocalVariableDeclarationStatement);
+            {
+                N(SyntaxKind.LocalKeyword);
+                N(SyntaxKind.LocalDeclarationName);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
+                }
+                N(SyntaxKind.VariableAttribute);
+                {
+                    N(SyntaxKind.LessThanToken);
+                    M(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.GreaterThanToken);
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Parser_GeneratesAnErrorDiagnosticWhen_ClosingTokenIsMissing()
+        {
+            UsingStatement(
+                "local a<const",
+                // (1,14): error LUA1006: Syntax error, '>' expected
+                // local a<const
+                Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments(">", "").WithLocation(1, 14));
+
+            N(SyntaxKind.LocalVariableDeclarationStatement);
+            {
+                N(SyntaxKind.LocalKeyword);
+                N(SyntaxKind.LocalDeclarationName);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
+                }
+                N(SyntaxKind.VariableAttribute);
+                {
+                    N(SyntaxKind.LessThanToken);
+                    N(SyntaxKind.IdentifierToken, "const");
+                    M(SyntaxKind.GreaterThanToken);
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Parser_ParsesLocalDeclaration_WithSingleVariableAndNoValue()
+        {
+            UsingStatement("local a<const>");
+
+            N(SyntaxKind.LocalVariableDeclarationStatement);
+            {
+                N(SyntaxKind.LocalKeyword);
+                N(SyntaxKind.LocalDeclarationName);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
+                    N(SyntaxKind.VariableAttribute);
+                    {
+                        N(SyntaxKind.LessThanToken);
+                        N(SyntaxKind.IdentifierToken, "const");
+                        N(SyntaxKind.GreaterThanToken);
+                    }
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Parser_ParsesLocalDeclaration_WithSingleVariableAndValue()
+        {
+            UsingStatement("local a<const> = 1");
+
+            N(SyntaxKind.LocalVariableDeclarationStatement);
+            {
+                N(SyntaxKind.LocalKeyword);
+                N(SyntaxKind.LocalDeclarationName);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
+                    N(SyntaxKind.VariableAttribute);
+                    {
+                        N(SyntaxKind.LessThanToken);
+                        N(SyntaxKind.IdentifierToken, "const");
+                        N(SyntaxKind.GreaterThanToken);
+                    }
+                }
+                N(SyntaxKind.EqualsValuesClause);
+                {
+                    N(SyntaxKind.EqualsToken);
+                    N(SyntaxKind.NumericalLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "1");
+                    }
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Parser_ParsesLocalDeclaration_WithMultipleVariablesAndNoValue()
+        {
+            UsingStatement("local a<const>, b<const>");
+
+            N(SyntaxKind.LocalVariableDeclarationStatement);
+            {
+                N(SyntaxKind.LocalKeyword);
+                N(SyntaxKind.LocalDeclarationName);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
+                    N(SyntaxKind.VariableAttribute);
+                    {
+                        N(SyntaxKind.LessThanToken);
+                        N(SyntaxKind.IdentifierToken, "const");
+                        N(SyntaxKind.GreaterThanToken);
+                    }
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.LocalDeclarationName);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "b");
+                    }
+                    N(SyntaxKind.VariableAttribute);
+                    {
+                        N(SyntaxKind.LessThanToken);
+                        N(SyntaxKind.IdentifierToken, "const");
+                        N(SyntaxKind.GreaterThanToken);
+                    }
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Parser_ParsesLocalDeclaration_WithMultipleVariablesAndValues()
+        {
+            UsingStatement("local a<const>, b<const> = 1, 2");
+
+            N(SyntaxKind.LocalVariableDeclarationStatement);
+            {
+                N(SyntaxKind.LocalKeyword);
+                N(SyntaxKind.LocalDeclarationName);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
+                    N(SyntaxKind.VariableAttribute);
+                    {
+                        N(SyntaxKind.LessThanToken);
+                        N(SyntaxKind.IdentifierToken, "const");
+                        N(SyntaxKind.GreaterThanToken);
+                    }
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.LocalDeclarationName);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "b");
+                    }
+                    N(SyntaxKind.VariableAttribute);
+                    {
+                        N(SyntaxKind.LessThanToken);
+                        N(SyntaxKind.IdentifierToken, "const");
+                        N(SyntaxKind.GreaterThanToken);
+                    }
+                }
+                N(SyntaxKind.EqualsValuesClause);
+                {
+                    N(SyntaxKind.EqualsToken);
+                    N(SyntaxKind.NumericalLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "1");
+                    }
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericalLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "2");
+                    }
+                }
+            }
+            EOF();
+        }
+
+        [Theory]
+        [RandomSpaceInserterData("local a", "<", "const", ">, b", "<", "const", "> = 1, 2")]
+        public void Parser_WorksWithSpacesInsideTheAttribute(string code)
+        {
+            UsingStatement(code);
+
+            N(SyntaxKind.LocalVariableDeclarationStatement);
+            {
+                N(SyntaxKind.LocalKeyword);
+                N(SyntaxKind.LocalDeclarationName);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
+                    N(SyntaxKind.VariableAttribute);
+                    {
+                        N(SyntaxKind.LessThanToken);
+                        N(SyntaxKind.IdentifierToken, "const");
+                        N(SyntaxKind.GreaterThanToken);
+                    }
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.LocalDeclarationName);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "b");
+                    }
+                    N(SyntaxKind.VariableAttribute);
+                    {
+                        N(SyntaxKind.LessThanToken);
+                        N(SyntaxKind.IdentifierToken, "const");
+                        N(SyntaxKind.GreaterThanToken);
+                    }
+                }
+                N(SyntaxKind.EqualsValuesClause);
+                {
+                    N(SyntaxKind.EqualsToken);
+                    N(SyntaxKind.NumericalLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "1");
+                    }
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericalLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "2");
+                    }
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Parser_AllowsMixingOfAttributedAndUnattributedVariables()
+        {
+            UsingStatement("local a, b<const>, c, d<const>, e<const>, f, g = 1, 2, 3, 4, 5, 6");
+
+            N(SyntaxKind.LocalVariableDeclarationStatement);
+            {
+                N(SyntaxKind.LocalKeyword);
+                N(SyntaxKind.LocalDeclarationName);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.LocalDeclarationName);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "b");
+                    }
+                    N(SyntaxKind.VariableAttribute);
+                    {
+                        N(SyntaxKind.LessThanToken);
+                        N(SyntaxKind.IdentifierToken, "const");
+                        N(SyntaxKind.GreaterThanToken);
+                    }
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.LocalDeclarationName);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "c");
+                    }
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.LocalDeclarationName);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "d");
+                    }
+                    N(SyntaxKind.VariableAttribute);
+                    {
+                        N(SyntaxKind.LessThanToken);
+                        N(SyntaxKind.IdentifierToken, "const");
+                        N(SyntaxKind.GreaterThanToken);
+                    }
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.LocalDeclarationName);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "e");
+                    }
+                    N(SyntaxKind.VariableAttribute);
+                    {
+                        N(SyntaxKind.LessThanToken);
+                        N(SyntaxKind.IdentifierToken, "const");
+                        N(SyntaxKind.GreaterThanToken);
+                    }
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.LocalDeclarationName);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "f");
+                    }
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.LocalDeclarationName);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "g");
+                    }
+                }
+                N(SyntaxKind.EqualsValuesClause);
+                {
+                    N(SyntaxKind.EqualsToken);
+                    N(SyntaxKind.NumericalLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "1");
+                    }
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericalLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "2");
+                    }
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericalLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "3");
+                    }
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericalLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "4");
+                    }
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericalLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "5");
+                    }
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericalLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "6");
+                    }
+                }
+            }
+            EOF();
+        }
+    }
+}

--- a/src/Compilers/Lua/Test/Portable/Parsing/ParsingTestsBase.cs
+++ b/src/Compilers/Lua/Test/Portable/Parsing/ParsingTestsBase.cs
@@ -13,13 +13,13 @@ using Xunit.Abstractions;
 
 namespace Loretta.CodeAnalysis.Lua.UnitTests.Parsing
 {
-    public abstract class ParsingTests : LuaTestBase, IDisposable
+    public abstract class ParsingTestsBase : LuaTestBase, IDisposable
     {
         private LuaSyntaxNode? _node;
         private IEnumerator<SyntaxNodeOrToken>? _treeEnumerator;
         private readonly ITestOutputHelper _output;
 
-        public ParsingTests(ITestOutputHelper output)
+        public ParsingTestsBase(ITestOutputHelper output)
         {
             _output = output;
         }

--- a/src/Compilers/Lua/Test/Portable/Scoping/CanBeAccessedInTests.cs
+++ b/src/Compilers/Lua/Test/Portable/Scoping/CanBeAccessedInTests.cs
@@ -12,7 +12,7 @@ namespace Loretta.CodeAnalysis.Lua.UnitTests.Scoping
             var (tree, script) = ParseScript("local a = 1 print(a)");
             var root = Assert.IsType<CompilationUnitSyntax>(tree.GetRoot());
             var assignment = Assert.IsType<LocalVariableDeclarationStatementSyntax>(root.Statements.Statements[0]);
-            var name = Assert.IsType<IdentifierNameSyntax>(assignment.Names[0]);
+            var name = Assert.IsType<LocalDeclarationNameSyntax>(assignment.Names[0]);
 
             var variable = script.GetVariable(name);
 
@@ -30,7 +30,7 @@ namespace Loretta.CodeAnalysis.Lua.UnitTests.Scoping
                                              "end");
             var root = Assert.IsType<CompilationUnitSyntax>(tree.GetRoot());
             var assignment = Assert.IsType<LocalVariableDeclarationStatementSyntax>(root.Statements.Statements[0]);
-            var name = Assert.IsType<IdentifierNameSyntax>(assignment.Names[0]);
+            var name = Assert.IsType<LocalDeclarationNameSyntax>(assignment.Names[0]);
             var doStatement = Assert.IsType<DoStatementSyntax>(root.Statements.Statements[1]);
 
             var variable = script.GetVariable(name);
@@ -51,7 +51,7 @@ namespace Loretta.CodeAnalysis.Lua.UnitTests.Scoping
             var root = Assert.IsType<CompilationUnitSyntax>(tree.GetRoot());
             var doStatement = Assert.IsType<DoStatementSyntax>(root.Statements.Statements[0]);
             var assignment = Assert.IsType<LocalVariableDeclarationStatementSyntax>(doStatement.Body.Statements[0]);
-            var name = Assert.IsType<IdentifierNameSyntax>(assignment.Names[0]);
+            var name = Assert.IsType<LocalDeclarationNameSyntax>(assignment.Names[0]);
 
             var variable = script.GetVariable(name);
             var rootScope = script.GetScope(root);

--- a/src/Compilers/Lua/Test/Utilities/RandomSpaceInserter.cs
+++ b/src/Compilers/Lua/Test/Utilities/RandomSpaceInserter.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Loretta.CodeAnalysis.Lua.Test.Utilities
+{
+    public static class RandomSpaceInserter
+    {
+        public static IEnumerable<string> Enumerate(params string[] parts)
+        {
+            if (parts.Length is < 1 or > 64)
+                throw new ArgumentOutOfRangeException(nameof(parts));
+
+            var spaceLocations = parts.Length - 1;
+            var builder = new StringBuilder();
+
+            var lastCase = (1UL << spaceLocations) - 1;
+
+            for (var spaces = 0UL; spaces <= lastCase; spaces++)
+            {
+                builder.Clear();
+
+                for (var partIdx = 0; partIdx < parts.Length - 1; partIdx++)
+                {
+                    builder.Append(parts[partIdx]);
+                    if (((1UL << partIdx) & spaces) != 0)
+                        builder.Append(' ');
+                }
+                builder.Append(parts[^1]);
+
+                yield return builder.ToString();
+            }
+        }
+
+        public static IEnumerable<object[]> MemberDataEnumerate(params string[] parts)
+        {
+            foreach (var result in Enumerate(parts))
+            {
+                yield return new object[] { result };
+            }
+        }
+    }
+}

--- a/src/Compilers/Lua/Test/Utilities/RandomSpaceInserterDataAttribute.cs
+++ b/src/Compilers/Lua/Test/Utilities/RandomSpaceInserterDataAttribute.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit.Sdk;
+
+namespace Loretta.CodeAnalysis.Lua.Test.Utilities
+{
+    public class RandomSpaceInserterDataAttribute : DataAttribute
+    {
+        private readonly string[] _parts;
+
+        public RandomSpaceInserterDataAttribute(params string[] parts)
+        {
+            _parts = parts;
+        }
+
+        public override IEnumerable<object[]> GetData(MethodInfo testMethod) =>
+            RandomSpaceInserter.MemberDataEnumerate(_parts);
+    }
+}


### PR DESCRIPTION
Implements local variable attributes.

Has a breaking change since attributes can only be in locals and adding it to `IdentifierNameSyntax` would result in allowing it in unwanted locations.

Fixes #31.