### PR TITLE
Project modernization

### DIFF
--- a/Loretta.sln
+++ b/Loretta.sln
@@ -47,6 +47,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Loretta.CodeAnalysis.Lua.Ex
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{DA213632-8774-47C8-97B7-BC1C55F6E519}"
 	ProjectSection(SolutionItems) = preProject
+		build\BaseProject.props = build\BaseProject.props
 		build\LibraryProject.props = build\LibraryProject.props
 	EndProjectSection
 EndProject

--- a/build/BaseProject.props
+++ b/build/BaseProject.props
@@ -1,0 +1,23 @@
+<Project>
+
+  <PropertyGroup>
+    <!-- Treat all non-nullable reference types warnings as errors (as it should be). -->
+    <WarningsAsErrors>CS8600;CS8601;CS8602;CS8603;CS8604;CS8605;CS8607;CS8608;CS8609;CS8610;CS8611;CS8612;CS8613;CS8614;CS8615;CS8616;CS8617;CS8618;CS8619;CS8620;CS8621;CS8622;CS8624;CS8625;CS8629;CS8631;CS8633;CS8634;CS8643;CS8644;CS8645;CS8655;CS8667;CS8670;CS8714;RS0016;RS0017</WarningsAsErrors>
+  </PropertyGroup>
+
+  <!-- Compilation props -->
+  <PropertyGroup>
+    <LangVersion>preview</LangVersion>
+    <Nullable>enable</Nullable>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0-2.22114.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/build/BaseProject.props
+++ b/build/BaseProject.props
@@ -11,6 +11,8 @@
     <Nullable>enable</Nullable>
     <AnalysisLevel>latest</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/BaseProject.props
+++ b/build/BaseProject.props
@@ -9,11 +9,21 @@
   <PropertyGroup>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
     <AnalysisLevel>latest</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
+  <!-- Nuget packing props -->
+  <PropertyGroup>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>
+  
+  <!-- Implicit Usings -->
+  <ItemGroup>
+    <Using Include="System.Collections.Immutable" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0-2.22114.1">

--- a/build/LibraryProject.props
+++ b/build/LibraryProject.props
@@ -13,6 +13,11 @@
     <IsPublishable>true</IsPublishable>
   </PropertyGroup>
 
+  <!-- Implicit Usings -->
+  <ItemGroup>
+    <Using Include="Loretta.Utilities" />
+  </ItemGroup>
+
   <!-- Package props -->
   <PropertyGroup>
     <Authors>GGG KILLER</Authors>

--- a/build/LibraryProject.props
+++ b/build/LibraryProject.props
@@ -7,12 +7,10 @@
     <TargetFrameworks Condition="'$(IsUnusedAnalysis)' == 'true'">netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
-  <!-- Compilation props -->
+  <!-- Allow packing -->
   <PropertyGroup>
-    <LangVersion>preview</LangVersion>
-    <Nullable>enable</Nullable>
-    <AnalysisLevel>latest</AnalysisLevel>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <IsPackable>true</IsPackable>
+    <IsPublishable>true</IsPublishable>
   </PropertyGroup>
 
   <!-- Package props -->

--- a/build/LibraryProject.props
+++ b/build/LibraryProject.props
@@ -1,16 +1,15 @@
 ﻿<Project>
+  
+  <Import Project="$(MSBuildThisFileDirectory)BaseProject.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(IsUnusedAnalysis)' == 'true'">netcoreapp3.1</TargetFrameworks>
-    <!-- Treat all non-nullable reference types warnings as errors (as it should be). -->
-    <WarningsAsErrors>CS8600;CS8601;CS8602;CS8603;CS8604;CS8605;CS8607;CS8608;CS8609;CS8610;CS8611;CS8612;CS8613;CS8614;CS8615;CS8616;CS8617;CS8618;CS8619;CS8620;CS8621;CS8622;CS8624;CS8625;CS8629;CS8631;CS8633;CS8634;CS8643;CS8644;CS8645;CS8655;CS8667;CS8670;CS8714;RS0016;RS0017</WarningsAsErrors>
-
   </PropertyGroup>
 
   <!-- Compilation props -->
   <PropertyGroup>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <AnalysisLevel>latest</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/nuget.config
+++ b/nuget.config
@@ -4,5 +4,6 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="Roslyn Compiler" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/Compilers/Core/Portable/Collections/ArrayBuilderExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ArrayBuilderExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Loretta.CodeAnalysis.PooledObjects;
 

--- a/src/Compilers/Core/Portable/Collections/BitVector.cs
+++ b/src/Compilers/Core/Portable/Collections/BitVector.cs
@@ -1,10 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using Loretta.Utilities;
 using Word = System.UInt64;
 
 namespace Loretta.CodeAnalysis

--- a/src/Compilers/Core/Portable/Collections/Boxes.cs
+++ b/src/Compilers/Core/Portable/Collections/Boxes.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-
 namespace Loretta.CodeAnalysis
 {
     internal static class Boxes

--- a/src/Compilers/Core/Portable/Collections/CachingFactory.cs
+++ b/src/Compilers/Core/Portable/Collections/CachingFactory.cs
@@ -1,11 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Loretta.CodeAnalysis.PooledObjects;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Collections/CollectionsExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/CollectionsExtensions.cs
@@ -3,8 +3,6 @@
 
 #nullable enable
 
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Loretta.CodeAnalysis

--- a/src/Compilers/Core/Portable/Collections/DictionaryExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/DictionaryExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-
 namespace Loretta.CodeAnalysis
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/Collections/IdentifierCollection.Collection.cs
+++ b/src/Compilers/Core/Portable/Collections/IdentifierCollection.Collection.cs
@@ -1,10 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
 namespace Loretta.CodeAnalysis
 {
     internal partial class IdentifierCollection

--- a/src/Compilers/Core/Portable/Collections/IdentifierCollection.cs
+++ b/src/Compilers/Core/Portable/Collections/IdentifierCollection.cs
@@ -1,10 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using Loretta.Utilities;
-
 namespace Loretta.CodeAnalysis
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
@@ -1,20 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 using Loretta.CodeAnalysis.PooledObjects;
-using Loretta.Utilities;
-using System.Threading;
 
 #if DEBUG
-using System.Linq;
 #endif
 
 namespace Loretta.CodeAnalysis

--- a/src/Compilers/Core/Portable/Collections/ImmutableSegmentedDictionary.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableSegmentedDictionary.cs
@@ -1,10 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
 namespace Loretta.CodeAnalysis.Collections
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/Collections/ImmutableSegmentedDictionary`2+Builder+KeyCollection.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableSegmentedDictionary`2+Builder+KeyCollection.cs
@@ -1,10 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Collections
 {

--- a/src/Compilers/Core/Portable/Collections/ImmutableSegmentedDictionary`2+Builder+ValueCollection.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableSegmentedDictionary`2+Builder+ValueCollection.cs
@@ -1,10 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Collections
 {

--- a/src/Compilers/Core/Portable/Collections/ImmutableSegmentedDictionary`2+Builder.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableSegmentedDictionary`2+Builder.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Loretta.CodeAnalysis.Collections

--- a/src/Compilers/Core/Portable/Collections/ImmutableSegmentedDictionary`2+Enumerator.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableSegmentedDictionary`2+Enumerator.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
-using System.Collections.Generic;
 
 namespace Loretta.CodeAnalysis.Collections
 {

--- a/src/Compilers/Core/Portable/Collections/ImmutableSegmentedDictionary`2+KeyCollection+Enumerator.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableSegmentedDictionary`2+KeyCollection+Enumerator.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
-using System.Collections.Generic;
 
 namespace Loretta.CodeAnalysis.Collections
 {

--- a/src/Compilers/Core/Portable/Collections/ImmutableSegmentedDictionary`2+KeyCollection.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableSegmentedDictionary`2+KeyCollection.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 
 namespace Loretta.CodeAnalysis.Collections
 {

--- a/src/Compilers/Core/Portable/Collections/ImmutableSegmentedDictionary`2+PrivateInterlocked.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableSegmentedDictionary`2+PrivateInterlocked.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
-using System.Threading;
 
 namespace Loretta.CodeAnalysis.Collections
 {

--- a/src/Compilers/Core/Portable/Collections/ImmutableSegmentedDictionary`2+ValueCollection+Enumerator.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableSegmentedDictionary`2+ValueCollection+Enumerator.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
-using System.Collections.Generic;
 
 namespace Loretta.CodeAnalysis.Collections
 {

--- a/src/Compilers/Core/Portable/Collections/ImmutableSegmentedDictionary`2+ValueCollection.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableSegmentedDictionary`2+ValueCollection.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 
 namespace Loretta.CodeAnalysis.Collections
 {

--- a/src/Compilers/Core/Portable/Collections/ImmutableSegmentedDictionary`2.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableSegmentedDictionary`2.cs
@@ -1,10 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Loretta.CodeAnalysis.Collections

--- a/src/Compilers/Core/Portable/Collections/Internal/ArraySortHelper.cs
+++ b/src/Compilers/Core/Portable/Collections/Internal/ArraySortHelper.cs
@@ -7,10 +7,7 @@
 // See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
 // reference implementation.
 
-using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using Loretta.Utilities;
 
 #if NETCOREAPP
 using System.Numerics;

--- a/src/Compilers/Core/Portable/Collections/Internal/HashHelpers.cs
+++ b/src/Compilers/Core/Portable/Collections/Internal/HashHelpers.cs
@@ -7,9 +7,7 @@
 // See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
 // reference implementation.
 
-using System;
 using System.Runtime.CompilerServices;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Collections.Internal
 {

--- a/src/Compilers/Core/Portable/Collections/Internal/ICollectionDebugView`1.cs
+++ b/src/Compilers/Core/Portable/Collections/Internal/ICollectionDebugView`1.cs
@@ -7,8 +7,6 @@
 // See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
 // reference implementation.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace Loretta.CodeAnalysis.Collections.Internal

--- a/src/Compilers/Core/Portable/Collections/Internal/IDictionaryDebugView`2.cs
+++ b/src/Compilers/Core/Portable/Collections/Internal/IDictionaryDebugView`2.cs
@@ -7,8 +7,6 @@
 // See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
 // reference implementation.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace Loretta.CodeAnalysis.Collections.Internal

--- a/src/Compilers/Core/Portable/Collections/Internal/InsertionBehavior.cs
+++ b/src/Compilers/Core/Portable/Collections/Internal/InsertionBehavior.cs
@@ -7,8 +7,6 @@
 // See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
 // reference implementation.
 
-using System.Collections.Generic;
-
 namespace Loretta.CodeAnalysis.Collections.Internal
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/Collections/Internal/SegmentedArrayHelper.cs
+++ b/src/Compilers/Core/Portable/Collections/Internal/SegmentedArrayHelper.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using Loretta.Utilities;
-
 namespace Loretta.CodeAnalysis.Collections.Internal
 {
     internal static class SegmentedArrayHelper

--- a/src/Compilers/Core/Portable/Collections/Internal/ThrowHelper.cs
+++ b/src/Compilers/Core/Portable/Collections/Internal/ThrowHelper.cs
@@ -33,11 +33,8 @@
 // multiple times for different instantiation.
 //
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Collections.Internal
 {

--- a/src/Compilers/Core/Portable/Collections/Rope.cs
+++ b/src/Compilers/Core/Portable/Collections/Rope.cs
@@ -1,10 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using Loretta.CodeAnalysis.PooledObjects;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Collections/RoslynEnumerable.cs
+++ b/src/Compilers/Core/Portable/Collections/RoslynEnumerable.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using Loretta.CodeAnalysis.Collections;
 using Loretta.CodeAnalysis.Collections.Internal;
 

--- a/src/Compilers/Core/Portable/Collections/RoslynImmutableInterlocked.cs
+++ b/src/Compilers/Core/Portable/Collections/RoslynImmutableInterlocked.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Loretta.CodeAnalysis.Collections

--- a/src/Compilers/Core/Portable/Collections/SegmentedArray.cs
+++ b/src/Compilers/Core/Portable/Collections/SegmentedArray.cs
@@ -1,11 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Loretta.CodeAnalysis.Collections.Internal;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Collections
 {

--- a/src/Compilers/Core/Portable/Collections/SegmentedArray`1.cs
+++ b/src/Compilers/Core/Portable/Collections/SegmentedArray`1.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 using Loretta.CodeAnalysis.Collections.Internal;

--- a/src/Compilers/Core/Portable/Collections/SegmentedDictionary`2.cs
+++ b/src/Compilers/Core/Portable/Collections/SegmentedDictionary`2.cs
@@ -7,14 +7,11 @@
 // See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
 // reference implementation.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Loretta.CodeAnalysis.Collections.Internal;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Collections
 {

--- a/src/Compilers/Core/Portable/Collections/SegmentedList`1.cs
+++ b/src/Compilers/Core/Portable/Collections/SegmentedList`1.cs
@@ -7,9 +7,7 @@
 // See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
 // reference implementation.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;

--- a/src/Compilers/Core/Portable/Compilation/ParseOptions.cs
+++ b/src/Compilers/Core/Portable/Compilation/ParseOptions.cs
@@ -1,13 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Loretta.CodeAnalysis.PooledObjects;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/ConstantValue.cs
+++ b/src/Compilers/Core/Portable/ConstantValue.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/ConstantValueSpecialized.cs
+++ b/src/Compilers/Core/Portable/ConstantValueSpecialized.cs
@@ -1,10 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/CryptographicHashProvider.cs
+++ b/src/Compilers/Core/Portable/CryptographicHashProvider.cs
@@ -3,7 +3,6 @@
 
 using System.Security.Cryptography;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Debugging/SourceHashAlgorithms.cs
+++ b/src/Compilers/Core/Portable/Debugging/SourceHashAlgorithms.cs
@@ -3,9 +3,7 @@
 
 #nullable disable
 
-using System;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Debugging
 {

--- a/src/Compilers/Core/Portable/Diagnostic/CommonDiagnosticComparer.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/CommonDiagnosticComparer.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using Loretta.Utilities;
-
 namespace Loretta.CodeAnalysis
 {
     internal sealed class CommonDiagnosticComparer : IEqualityComparer<Diagnostic>

--- a/src/Compilers/Core/Portable/Diagnostic/CommonMessageProvider.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/CommonMessageProvider.cs
@@ -1,10 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Concurrent;
 using System.Globalization;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
@@ -1,13 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticDescriptor.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticDescriptor.cs
@@ -1,11 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using Loretta.Utilities;
-
 namespace Loretta.CodeAnalysis
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticFormatter.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticFormatter.cs
@@ -1,10 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Globalization;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticInfo.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticInfo.cs
@@ -1,13 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticWithInfo.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticWithInfo.cs
@@ -1,11 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic_SimpleDiagnostic.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic_SimpleDiagnostic.cs
@@ -1,12 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using Loretta.Utilities;
-
 namespace Loretta.CodeAnalysis
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/Diagnostic/ExternalFileLocation.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/ExternalFileLocation.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Diagnostic/FileLinePositionSpan.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/FileLinePositionSpan.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Diagnostic/LocalizableResourceString.FixedLocalizableString.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/LocalizableResourceString.FixedLocalizableString.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using Loretta.Utilities;
-
 namespace Loretta.CodeAnalysis
 {
     public abstract partial class LocalizableString

--- a/src/Compilers/Core/Portable/Diagnostic/LocalizableResourceString.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/LocalizableResourceString.cs
@@ -1,12 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Globalization;
-using System.Linq;
 using System.Resources;
 using Loretta.CodeAnalysis.PooledObjects;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Diagnostic/LocalizableString.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/LocalizableString.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-
 namespace Loretta.CodeAnalysis
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/Diagnostic/Location.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Location.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Loretta.CodeAnalysis.Text;

--- a/src/Compilers/Core/Portable/Diagnostic/SourceLocation.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/SourceLocation.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/InternalUtilities/ArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ArrayExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-
 namespace Loretta.Utilities
 {
     internal static class ArrayExtensions

--- a/src/Compilers/Core/Portable/InternalUtilities/EncodingExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/EncodingExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.IO;
 using System.Text;
 using Loretta.CodeAnalysis;
 

--- a/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
@@ -1,15 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Collections.ObjectModel;
-using System.Linq;
 using Loretta.CodeAnalysis;
 using Loretta.CodeAnalysis.PooledObjects;
-using Loretta.Utilities;
 
 #if DEBUG
 #endif

--- a/src/Compilers/Core/Portable/InternalUtilities/ExceptionUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ExceptionUtilities.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-
 namespace Loretta.Utilities
 {
     internal static class ExceptionUtilities

--- a/src/Compilers/Core/Portable/InternalUtilities/Hash.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/Hash.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using Loretta.CodeAnalysis;
 
 namespace Loretta.Utilities

--- a/src/Compilers/Core/Portable/InternalUtilities/IReadOnlyListExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/IReadOnlyListExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-
 namespace Loretta.Utilities
 {
     internal static class IReadOnlyListExtensions

--- a/src/Compilers/Core/Portable/InternalUtilities/ImmutableArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ImmutableArrayExtensions.cs
@@ -1,10 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-
 namespace Loretta.Utilities
 {
     internal static class ImmutableArrayExtensions

--- a/src/Compilers/Core/Portable/InternalUtilities/NonCopyableAttribute.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/NonCopyableAttribute.cs
@@ -3,8 +3,6 @@
 
 #nullable disable
 
-using System;
-
 namespace Loretta.Utilities
 {
     [AttributeUsage(AttributeTargets.Struct | AttributeTargets.GenericParameter)]

--- a/src/Compilers/Core/Portable/InternalUtilities/NonDefaultableAttribute.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/NonDefaultableAttribute.cs
@@ -3,8 +3,6 @@
 
 #nullable disable
 
-using System;
-
 namespace Loretta.Utilities
 {
     [AttributeUsage(AttributeTargets.Struct | AttributeTargets.GenericParameter)]

--- a/src/Compilers/Core/Portable/InternalUtilities/ReaderWriterLockSlimExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ReaderWriterLockSlimExtensions.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Threading;
-
 namespace Loretta.Utilities
 {
     internal static class ReaderWriterLockSlimExtensions

--- a/src/Compilers/Core/Portable/InternalUtilities/ReferenceEqualityComparer.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ReferenceEqualityComparer.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
 namespace Loretta.Utilities

--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.Collection.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.Collection.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-
 namespace Loretta.Utilities
 {
     internal static partial class SpecializedCollections

--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.Dictionary.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.Dictionary.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Loretta.Utilities

--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.Enumerable.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.Enumerable.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-
 namespace Loretta.Utilities
 {
     internal partial class SpecializedCollections

--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.Enumerator.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.Enumerator.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
 
 namespace Loretta.Utilities

--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.Enumerator`1.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.Enumerator`1.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-
 namespace Loretta.Utilities
 {
     internal partial class SpecializedCollections

--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.List.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.List.cs
@@ -1,10 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-
 namespace Loretta.Utilities
 {
     internal partial class SpecializedCollections

--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.Set.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.Set.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-
 namespace Loretta.Utilities
 {
     internal partial class SpecializedCollections

--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.ReadOnly.Collection.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.ReadOnly.Collection.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-
 namespace Loretta.Utilities
 {
     internal partial class SpecializedCollections

--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.ReadOnly.Enumerable`2.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.ReadOnly.Enumerable`2.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-
 namespace Loretta.Utilities
 {
     internal partial class SpecializedCollections

--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.ReadOnly.Set.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.ReadOnly.Set.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-
 namespace Loretta.Utilities
 {
     internal partial class SpecializedCollections

--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Singleton.Collection`1.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Singleton.Collection`1.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 
 namespace Loretta.Utilities
 {

--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Singleton.Enumerator`1.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Singleton.Enumerator`1.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
-using System.Collections.Generic;
 
 namespace Loretta.Utilities
 {

--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-
 namespace Loretta.Utilities
 {
     internal static partial class SpecializedCollections

--- a/src/Compilers/Core/Portable/InternalUtilities/StackGuard.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/StackGuard.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 

--- a/src/Compilers/Core/Portable/InternalUtilities/StringOrdinalComparer.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/StringOrdinalComparer.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-
 namespace Loretta.Utilities
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/InternalUtilities/StringTable.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/StringTable.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Text;
-using System.Threading;
 using Loretta.CodeAnalysis;
 using Loretta.CodeAnalysis.PooledObjects;
 

--- a/src/Compilers/Core/Portable/InternalUtilities/TextChangeRangeExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/TextChangeRangeExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Immutable;
 using Loretta.CodeAnalysis.PooledObjects;
 using Loretta.CodeAnalysis.Text;
 

--- a/src/Compilers/Core/Portable/InternalUtilities/TextKeyedCache.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/TextKeyedCache.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Threading;
 using Loretta.CodeAnalysis;
 using Loretta.CodeAnalysis.PooledObjects;
 

--- a/src/Compilers/Core/Portable/Loretta.CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/Loretta.CodeAnalysis.csproj
@@ -2,7 +2,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="../../../../build/LibraryProject.props" />
+  <Import Project="$(MSBuildThisFileDirectory)../../../../build/LibraryProject.props" />
 
   <PropertyGroup>
     <!-- NuGet -->

--- a/src/Compilers/Core/Portable/PooledObjects/ArrayBuilder.cs
+++ b/src/Compilers/Core/Portable/PooledObjects/ArrayBuilder.cs
@@ -1,11 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.PooledObjects
 {

--- a/src/Compilers/Core/Portable/PooledObjects/ObjectPool`1.cs
+++ b/src/Compilers/Core/Portable/PooledObjects/ObjectPool`1.cs
@@ -11,10 +11,7 @@
 // #define DETECT_LEAKS  //for now always enable DETECT_LEAKS in debug.
 // #endif
 
-using System;
 using System.Diagnostics;
-using System.Threading;
-using Loretta.Utilities;
 
 #if DETECT_LEAKS
 using System.Runtime.CompilerServices;

--- a/src/Compilers/Core/Portable/PooledObjects/PooledDelegates.cs
+++ b/src/Compilers/Core/Portable/PooledObjects/PooledDelegates.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-
 namespace Loretta.CodeAnalysis.PooledObjects
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/PooledObjects/PooledDictionary.cs
+++ b/src/Compilers/Core/Portable/PooledObjects/PooledDictionary.cs
@@ -1,10 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using Loretta.Utilities;
-
 namespace Loretta.CodeAnalysis.PooledObjects
 {
     // Dictionary that can be recycled via an object pool

--- a/src/Compilers/Core/Portable/PooledObjects/PooledHashSet.cs
+++ b/src/Compilers/Core/Portable/PooledObjects/PooledHashSet.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using Loretta.Utilities;
-
 namespace Loretta.CodeAnalysis.PooledObjects
 {
     // HashSet that can be recycled via an object pool

--- a/src/Compilers/Core/Portable/PooledObjects/PooledStringBuilder.cs
+++ b/src/Compilers/Core/Portable/PooledObjects/PooledStringBuilder.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.PooledObjects
 {

--- a/src/Compilers/Core/Portable/RealParser.cs
+++ b/src/Compilers/Core/Portable/RealParser.cs
@@ -1,12 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Serialization/ObjectBinder.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectBinder.cs
@@ -3,9 +3,6 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
-
 namespace Loretta.Utilities
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/Serialization/ObjectBinderSnapshot.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectBinderSnapshot.cs
@@ -3,10 +3,6 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-
 namespace Loretta.Utilities
 {
     internal readonly struct ObjectBinderSnapshot

--- a/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
@@ -3,11 +3,7 @@
 
 #nullable disable
 
-using System;
-using System.IO;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Loretta.CodeAnalysis;
 using Loretta.CodeAnalysis.Collections;
 using Loretta.CodeAnalysis.PooledObjects;

--- a/src/Compilers/Core/Portable/Serialization/ObjectWriter.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectWriter.cs
@@ -1,13 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading;
 using Loretta.CodeAnalysis;
 using Loretta.CodeAnalysis.PooledObjects;
 

--- a/src/Compilers/Core/Portable/SymbolDisplay/ObjectDisplayOptions.cs
+++ b/src/Compilers/Core/Portable/SymbolDisplay/ObjectDisplayOptions.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-
 namespace Loretta.CodeAnalysis
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/Syntax/AnnotationExtensions.cs
+++ b/src/Compilers/Core/Portable/Syntax/AnnotationExtensions.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.Linq;
-
 namespace Loretta.CodeAnalysis
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/Syntax/ChildSyntaxList.Enumerator.cs
+++ b/src/Compilers/Core/Portable/Syntax/ChildSyntaxList.Enumerator.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Syntax/ChildSyntaxList.Reversed.cs
+++ b/src/Compilers/Core/Portable/Syntax/ChildSyntaxList.Reversed.cs
@@ -1,11 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Syntax/ChildSyntaxList.cs
+++ b/src/Compilers/Core/Portable/Syntax/ChildSyntaxList.cs
@@ -1,11 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Syntax/CommonSyntaxNodeRemover.cs
+++ b/src/Compilers/Core/Portable/Syntax/CommonSyntaxNodeRemover.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Loretta.Utilities;
-
 namespace Loretta.CodeAnalysis.Syntax
 {
     internal static class CommonSyntaxNodeRemover

--- a/src/Compilers/Core/Portable/Syntax/GreenNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/GreenNode.cs
@@ -1,16 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using Loretta.CodeAnalysis.PooledObjects;
 using Loretta.CodeAnalysis.Syntax.InternalSyntax;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Syntax/GreenNodeExtensions.cs
+++ b/src/Compilers/Core/Portable/Syntax/GreenNodeExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using Loretta.CodeAnalysis.PooledObjects;
 
 namespace Loretta.CodeAnalysis

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/ChildSyntaxList.Reversed.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/ChildSyntaxList.Reversed.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-
 namespace Loretta.CodeAnalysis.Syntax.InternalSyntax
 {
     internal partial struct ChildSyntaxList

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/ChildSyntaxList.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/ChildSyntaxList.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-
 namespace Loretta.CodeAnalysis.Syntax.InternalSyntax
 {
     internal partial struct ChildSyntaxList

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SeparatedSyntaxList.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SeparatedSyntaxList.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Syntax.InternalSyntax
 {

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SeparatedSyntaxListBuilder.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SeparatedSyntaxListBuilder.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-
 namespace Loretta.CodeAnalysis.Syntax.InternalSyntax
 {
     // The null-suppression uses in this type are covered under the following issue to

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxDiagnosticInfoList.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxDiagnosticInfoList.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using Loretta.Utilities;
-
 namespace Loretta.CodeAnalysis.Syntax.InternalSyntax
 {
     // Avoid implementing IEnumerable so we do not get any unintentional boxing.

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxList.WithLotsOfChildren.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxList.WithLotsOfChildren.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Loretta.Utilities;
-
 namespace Loretta.CodeAnalysis.Syntax.InternalSyntax
 {
     internal partial class SyntaxList

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxList.WithManyChildren.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxList.WithManyChildren.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using Loretta.Utilities;
-
 namespace Loretta.CodeAnalysis.Syntax.InternalSyntax
 {
     internal partial class SyntaxList

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxList.WithThreeChildren.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxList.WithThreeChildren.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Loretta.Utilities;
-
 namespace Loretta.CodeAnalysis.Syntax.InternalSyntax
 {
     internal partial class SyntaxList

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxList.WithTwoChildren.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxList.WithTwoChildren.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Loretta.Utilities;
-
 namespace Loretta.CodeAnalysis.Syntax.InternalSyntax
 {
     internal partial class SyntaxList

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxList.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxList.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Loretta.Utilities;
-
 namespace Loretta.CodeAnalysis.Syntax.InternalSyntax
 {
     internal abstract partial class SyntaxList : GreenNode

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxListBuilder.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxListBuilder.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Syntax.InternalSyntax
 {

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxListPool.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxListPool.cs
@@ -1,10 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using Loretta.Utilities;
-
 namespace Loretta.CodeAnalysis.Syntax.InternalSyntax
 {
     internal class SyntaxListPool

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxList`1.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxList`1.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using Loretta.Utilities;
-
 namespace Loretta.CodeAnalysis.Syntax.InternalSyntax
 {
     internal partial struct SyntaxList<TNode> : IEquatable<SyntaxList<TNode>>

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxNodeCache.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxNodeCache.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics;
-using Loretta.Utilities;
 
 #if STATS
 using System.Threading;

--- a/src/Compilers/Core/Portable/Syntax/SeparatedSyntaxList.Enumerator.cs
+++ b/src/Compilers/Core/Portable/Syntax/SeparatedSyntaxList.Enumerator.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Loretta.CodeAnalysis

--- a/src/Compilers/Core/Portable/Syntax/SeparatedSyntaxList.cs
+++ b/src/Compilers/Core/Portable/Syntax/SeparatedSyntaxList.cs
@@ -1,13 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Syntax/SeparatedSyntaxListBuilder.cs
+++ b/src/Compilers/Core/Portable/Syntax/SeparatedSyntaxListBuilder.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using Loretta.Utilities;
-
 namespace Loretta.CodeAnalysis.Syntax
 {
     internal struct SeparatedSyntaxListBuilder<TNode> where TNode : SyntaxNode

--- a/src/Compilers/Core/Portable/Syntax/SyntaxAnnotation.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxAnnotation.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {
@@ -45,7 +43,7 @@ namespace Loretta.CodeAnalysis
         /// </summary>
         public SyntaxAnnotation()
         {
-            _id = System.Threading.Interlocked.Increment(ref s_nextId);
+            _id = Interlocked.Increment(ref s_nextId);
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/Syntax/SyntaxDiffer.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxDiffer.cs
@@ -1,12 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList.SeparatedWithManyWeakChildren.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList.SeparatedWithManyWeakChildren.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-
 namespace Loretta.CodeAnalysis.Syntax
 {
     internal partial class SyntaxList

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList.WithManyWeakChildren.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList.WithManyWeakChildren.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-
 namespace Loretta.CodeAnalysis.Syntax
 {
     internal partial class SyntaxList

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList.cs
@@ -1,10 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using Loretta.Utilities;
-
 namespace Loretta.CodeAnalysis.Syntax
 {
     internal abstract partial class SyntaxList : SyntaxNode

--- a/src/Compilers/Core/Portable/Syntax/SyntaxListBuilder.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxListBuilder.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Syntax
 {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList`1.Enumerator.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList`1.Enumerator.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Loretta.CodeAnalysis

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList`1.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList`1.cs
@@ -1,13 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using Loretta.CodeAnalysis.Syntax;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNavigator.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNavigator.cs
@@ -1,10 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using Loretta.CodeAnalysis.PooledObjects;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.Iterators.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.Iterators.cs
@@ -1,12 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Loretta.CodeAnalysis.PooledObjects;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
@@ -1,16 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNodeExtensions.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNodeExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Loretta.CodeAnalysis

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNodeExtensions_Tracking.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNodeExtensions_Tracking.cs
@@ -1,12 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
 using System.Runtime.CompilerServices;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrToken.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrToken.cs
@@ -1,13 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrTokenList.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrTokenList.cs
@@ -1,14 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Loretta.CodeAnalysis.Syntax;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrTokenListBuilder.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrTokenListBuilder.cs
@@ -1,10 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using Loretta.Utilities;
-
 namespace Loretta.CodeAnalysis.Syntax
 {
     internal class SyntaxNodeOrTokenListBuilder

--- a/src/Compilers/Core/Portable/Syntax/SyntaxReference.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxReference.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Threading;
-using System.Threading.Tasks;
 using Loretta.CodeAnalysis.Text;
 
 namespace Loretta.CodeAnalysis

--- a/src/Compilers/Core/Portable/Syntax/SyntaxRemoveOptions.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxRemoveOptions.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-
 namespace Loretta.CodeAnalysis
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
@@ -1,14 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Runtime.InteropServices;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTokenList.Enumerator.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTokenList.Enumerator.cs
@@ -1,12 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTokenList.Reversed.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTokenList.Reversed.cs
@@ -1,12 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTokenList.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTokenList.cs
@@ -1,14 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
 using Loretta.CodeAnalysis.Syntax;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTokenListBuilder.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTokenListBuilder.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using Loretta.Utilities;
-
 namespace Loretta.CodeAnalysis.Syntax
 {
     internal class SyntaxTokenListBuilder

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTree.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTree.cs
@@ -1,11 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Loretta.CodeAnalysis.Text;
 
 namespace Loretta.CodeAnalysis

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTreeComparer.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTreeComparer.cs
@@ -1,10 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTreeExtensions.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTreeExtensions.cs
@@ -1,12 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTrivia.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTrivia.cs
@@ -1,14 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Runtime.InteropServices;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTriviaList.Enumerator.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTriviaList.Enumerator.cs
@@ -1,11 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTriviaList.Reversed.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTriviaList.Reversed.cs
@@ -1,11 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTriviaList.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTriviaList.cs
@@ -1,15 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
 using Loretta.CodeAnalysis.PooledObjects;
 using Loretta.CodeAnalysis.Syntax;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTriviaListBuilder.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTriviaListBuilder.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-
 namespace Loretta.CodeAnalysis.Syntax
 {
     internal class SyntaxTriviaListBuilder

--- a/src/Compilers/Core/Portable/Text/ChangedText.cs
+++ b/src/Compilers/Core/Portable/Text/ChangedText.cs
@@ -1,12 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Text;
 using Loretta.CodeAnalysis.PooledObjects;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Text
 {

--- a/src/Compilers/Core/Portable/Text/CompositeText.cs
+++ b/src/Compilers/Core/Portable/Text/CompositeText.cs
@@ -1,12 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Text;
 using Loretta.CodeAnalysis.PooledObjects;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Text
 {

--- a/src/Compilers/Core/Portable/Text/LargeText.cs
+++ b/src/Compilers/Core/Portable/Text/LargeText.cs
@@ -1,13 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Immutable;
-using System.IO;
 using System.Text;
-using System.Threading;
 using Loretta.CodeAnalysis.PooledObjects;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Text
 {

--- a/src/Compilers/Core/Portable/Text/LargeTextWriter.cs
+++ b/src/Compilers/Core/Portable/Text/LargeTextWriter.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Immutable;
 using System.Text;
 using Loretta.CodeAnalysis.PooledObjects;
 

--- a/src/Compilers/Core/Portable/Text/LinePosition.cs
+++ b/src/Compilers/Core/Portable/Text/LinePosition.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.Serialization;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Text
 {

--- a/src/Compilers/Core/Portable/Text/LinePositionSpan.cs
+++ b/src/Compilers/Core/Portable/Text/LinePositionSpan.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.Serialization;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Text
 {

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -1,17 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading;
 using Loretta.CodeAnalysis.Debugging;
 using Loretta.CodeAnalysis.PooledObjects;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Text
 {

--- a/src/Compilers/Core/Portable/Text/SourceTextComparer.cs
+++ b/src/Compilers/Core/Portable/Text/SourceTextComparer.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using Loretta.Utilities;
-
 namespace Loretta.CodeAnalysis.Text
 {
     internal class SourceTextComparer : IEqualityComparer<SourceText?>

--- a/src/Compilers/Core/Portable/Text/SourceTextContainer.cs
+++ b/src/Compilers/Core/Portable/Text/SourceTextContainer.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-
 namespace Loretta.CodeAnalysis.Text
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/Text/SourceTextStream.cs
+++ b/src/Compilers/Core/Portable/Text/SourceTextStream.cs
@@ -1,10 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.IO;
 using System.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Text
 {

--- a/src/Compilers/Core/Portable/Text/SourceTextWriter.cs
+++ b/src/Compilers/Core/Portable/Text/SourceTextWriter.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.IO;
 using System.Text;
 
 namespace Loretta.CodeAnalysis.Text

--- a/src/Compilers/Core/Portable/Text/StringBuilderText.cs
+++ b/src/Compilers/Core/Portable/Text/StringBuilderText.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Text
 {

--- a/src/Compilers/Core/Portable/Text/StringText.cs
+++ b/src/Compilers/Core/Portable/Text/StringText.cs
@@ -1,12 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Immutable;
-using System.IO;
 using System.Text;
-using System.Threading;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Text
 {

--- a/src/Compilers/Core/Portable/Text/SubText.cs
+++ b/src/Compilers/Core/Portable/Text/SubText.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Text;
 
 namespace Loretta.CodeAnalysis.Text

--- a/src/Compilers/Core/Portable/Text/TextChange.cs
+++ b/src/Compilers/Core/Portable/Text/TextChange.cs
@@ -1,11 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.Serialization;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Text
 {

--- a/src/Compilers/Core/Portable/Text/TextChangeEventArgs.cs
+++ b/src/Compilers/Core/Portable/Text/TextChangeEventArgs.cs
@@ -1,10 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-
 namespace Loretta.CodeAnalysis.Text
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/Text/TextChangeRange.cs
+++ b/src/Compilers/Core/Portable/Text/TextChangeRange.cs
@@ -1,10 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Text
 {

--- a/src/Compilers/Core/Portable/Text/TextLine.cs
+++ b/src/Compilers/Core/Portable/Text/TextLine.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using Loretta.Utilities;
-
 namespace Loretta.CodeAnalysis.Text
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/Text/TextLineCollection.cs
+++ b/src/Compilers/Core/Portable/Text/TextLineCollection.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Loretta.CodeAnalysis.Text

--- a/src/Compilers/Core/Portable/Text/TextSpan.cs
+++ b/src/Compilers/Core/Portable/Text/TextSpan.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.Serialization;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Text
 {

--- a/src/Compilers/Core/Portable/TreeDumper.cs
+++ b/src/Compilers/Core/Portable/TreeDumper.cs
@@ -1,14 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
 using System.Reflection;
 using System.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis
 {

--- a/src/Compilers/Core/Test/Utilities/Assert/AssertEx.cs
+++ b/src/Compilers/Core/Test/Utilities/Assert/AssertEx.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using System;
 using System.Text;
 using Xunit;
 

--- a/src/Compilers/Core/Test/Utilities/Assert/ConditionalFactAttribute.cs
+++ b/src/Compilers/Core/Test/Utilities/Assert/ConditionalFactAttribute.cs
@@ -3,8 +3,6 @@
 
 #nullable disable
 
-using System;
-using System.IO;
 using System.Runtime.InteropServices;
 using Loretta.CodeAnalysis.Test.Utilities;
 using Xunit;

--- a/src/Compilers/Core/Test/Utilities/Assert/DiffUtil.cs
+++ b/src/Compilers/Core/Test/Utilities/Assert/DiffUtil.cs
@@ -3,10 +3,7 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 
 namespace Loretta.CodeAnalysis.Test.Utilities
 {

--- a/src/Compilers/Core/Test/Utilities/Assert/WorkItemAttribute.cs
+++ b/src/Compilers/Core/Test/Utilities/Assert/WorkItemAttribute.cs
@@ -3,8 +3,6 @@
 
 #nullable disable
 
-using System;
-
 namespace Loretta.Test.Utilities
 {
     /// <summary>

--- a/src/Compilers/Core/Test/Utilities/CommonTestBase.cs
+++ b/src/Compilers/Core/Test/Utilities/CommonTestBase.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using System;
 using Loretta.Test.Utilities;
 
 namespace Loretta.CodeAnalysis.Test.Utilities

--- a/src/Compilers/Core/Test/Utilities/Compilation/RuntimeUtilities.cs
+++ b/src/Compilers/Core/Test/Utilities/Compilation/RuntimeUtilities.cs
@@ -4,7 +4,6 @@
 
 #nullable disable
 
-using System;
 using System.Reflection;
 
 namespace Loretta.CodeAnalysis.Test.Utilities

--- a/src/Compilers/Core/Test/Utilities/Diagnostics/DiagnosticDescription.cs
+++ b/src/Compilers/Core/Test/Utilities/Diagnostics/DiagnosticDescription.cs
@@ -348,7 +348,7 @@ namespace Loretta.CodeAnalysis.Test.Utilities
 
             if (_squiggledText != null)
             {
-                if (_squiggledText.Contains("\n") || _squiggledText.Contains("\\") || _squiggledText.Contains("\""))
+                if (_squiggledText.Contains('\n') || _squiggledText.Contains('\\') || _squiggledText.Contains('"'))
                 {
                     sb.Append(", @\"");
                     sb.Append(_squiggledText.Replace("\"", "\"\""));

--- a/src/Compilers/Core/Test/Utilities/Diagnostics/DiagnosticDescription.cs
+++ b/src/Compilers/Core/Test/Utilities/Diagnostics/DiagnosticDescription.cs
@@ -3,16 +3,12 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using Loretta.CodeAnalysis;
 using Loretta.CodeAnalysis.PooledObjects;
 using Loretta.CodeAnalysis.Text;
 using Loretta.Test.Utilities;
-using Loretta.Utilities;
 using Xunit;
 
 namespace Loretta.CodeAnalysis.Test.Utilities

--- a/src/Compilers/Core/Test/Utilities/Diagnostics/DiagnosticExtensions.cs
+++ b/src/Compilers/Core/Test/Utilities/Diagnostics/DiagnosticExtensions.cs
@@ -3,13 +3,8 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
 using Loretta.CodeAnalysis.Test.Utilities;
 using Loretta.Test.Utilities;
-using Loretta.Utilities;
 using Xunit;
 
 namespace Loretta.CodeAnalysis

--- a/src/Compilers/Core/Test/Utilities/FX/EnsureEnglishUICulture.cs
+++ b/src/Compilers/Core/Test/Utilities/FX/EnsureEnglishUICulture.cs
@@ -32,7 +32,7 @@ namespace Loretta.Test.Utilities
 
         public EnsureEnglishUICulture()
         {
-            _threadId = Thread.CurrentThread.ManagedThreadId;
+            _threadId = Environment.CurrentManagedThreadId;
             var preferred = PreferredOrNull;
 
             if (preferred != null)
@@ -46,9 +46,9 @@ namespace Loretta.Test.Utilities
 
         public void Dispose()
         {
-            Debug.Assert(_threadId == Thread.CurrentThread.ManagedThreadId);
+            Debug.Assert(_threadId == Environment.CurrentManagedThreadId);
 
-            if (_needToRestore && _threadId == Thread.CurrentThread.ManagedThreadId)
+            if (_needToRestore && _threadId == Environment.CurrentManagedThreadId)
             {
                 _needToRestore = false;
                 CultureInfo.CurrentUICulture = _threadUICulture;

--- a/src/Compilers/Core/Test/Utilities/FX/EnsureEnglishUICulture.cs
+++ b/src/Compilers/Core/Test/Utilities/FX/EnsureEnglishUICulture.cs
@@ -3,10 +3,8 @@
 
 #nullable disable
 
-using System;
 using System.Diagnostics;
 using System.Globalization;
-using System.Threading;
 
 namespace Loretta.Test.Utilities
 {

--- a/src/Compilers/Core/Test/Utilities/Loretta.CodeAnalysis.Test.Utilities.csproj
+++ b/src/Compilers/Core/Test/Utilities/Loretta.CodeAnalysis.Test.Utilities.csproj
@@ -8,8 +8,6 @@
     <OutputType>Library</OutputType>
     <TargetFrameworks>net5.0;netcoreapp3.1;netstandard2.0;net472</TargetFrameworks>
     <TargetFrameworks Condition="'$(IsUnusedAnalysis)' == 'true'">net5.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Compilers/Core/Test/Utilities/Loretta.CodeAnalysis.Test.Utilities.csproj
+++ b/src/Compilers/Core/Test/Utilities/Loretta.CodeAnalysis.Test.Utilities.csproj
@@ -2,6 +2,8 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$(MSBuildThisFileDirectory)../../../../../build/BaseProject.props" />
+
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net5.0;netcoreapp3.1;netstandard2.0;net472</TargetFrameworks>

--- a/src/Compilers/Core/Test/Utilities/Loretta.CodeAnalysis.Test.Utilities.csproj
+++ b/src/Compilers/Core/Test/Utilities/Loretta.CodeAnalysis.Test.Utilities.csproj
@@ -10,9 +10,15 @@
     <TargetFrameworks Condition="'$(IsUnusedAnalysis)' == 'true'">net5.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="Loretta.CodeAnalysis.Lua.Test.Utilities" />
     <InternalsVisibleTo Include="Loretta.CodeAnalysis.Lua.UnitTests" />
+  </ItemGroup>
+
+  <!-- Implicit Usings -->
+  <ItemGroup>
+    <Using Include="Loretta.Utilities" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Compilers/Core/Test/Utilities/ModuleInitializer.cs
+++ b/src/Compilers/Core/Test/Utilities/ModuleInitializer.cs
@@ -11,7 +11,9 @@ namespace Loretta.Test.Utilities
 {
     internal static class ModuleInitializer
     {
+#pragma warning disable CA2255 // The 'ModuleInitializer' attribute should not be used in libraries
         [ModuleInitializer]
+#pragma warning restore CA2255 // The 'ModuleInitializer' attribute should not be used in libraries
         internal static void Initialize()
         {
             Trace.Listeners.Clear();

--- a/src/Compilers/Core/Test/Utilities/TestBase.cs
+++ b/src/Compilers/Core/Test/Utilities/TestBase.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using System;
 using System.Xml.Linq;
 using Loretta.CodeAnalysis;
 using Loretta.CodeAnalysis.Test.Utilities;

--- a/src/Compilers/Core/Test/Utilities/TestHelpers.cs
+++ b/src/Compilers/Core/Test/Utilities/TestHelpers.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using System;
 using System.Diagnostics;
 using System.Xml.Linq;
 using Loretta.CodeAnalysis;

--- a/src/Compilers/Core/Test/Utilities/ThrowingTraceListener.cs
+++ b/src/Compilers/Core/Test/Utilities/ThrowingTraceListener.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics;
 
 #nullable enable

--- a/src/Compilers/Lua/CommandLine/ConsoleTimingLoggerTextWriter.cs
+++ b/src/Compilers/Lua/CommandLine/ConsoleTimingLoggerTextWriter.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Text;
+﻿using System.Text;
 using Tsu.Timing;
 
 namespace Loretta.CLI

--- a/src/Compilers/Lua/CommandLine/Loretta.CLI.csproj
+++ b/src/Compilers/Lua/CommandLine/Loretta.CLI.csproj
@@ -5,13 +5,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <IsPackable>false</IsPackable>
-    <IsPublishable>false</IsPublishable>
-    <LangVersion>preview</LangVersion>
-    <Nullable>enable</Nullable>
-    <AnalysisLevel>latest</AnalysisLevel>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,11 +26,6 @@
     <None Update="binaries\**">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="samples\metatables\" />
-    <Folder Include="samples\boolops\" />
   </ItemGroup>
 
 </Project>

--- a/src/Compilers/Lua/CommandLine/Loretta.CLI.csproj
+++ b/src/Compilers/Lua/CommandLine/Loretta.CLI.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$(MSBuildThisFileDirectory)../../../../build/BaseProject.props"/>
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>

--- a/src/Compilers/Lua/CommandLine/Program.cs
+++ b/src/Compilers/Lua/CommandLine/Program.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.CommandLine;
+﻿using System.CommandLine;
 using System.CommandLine.NamingConventionBinder;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using System.Text;
 using Loretta.CodeAnalysis;
 using Loretta.CodeAnalysis.Lua;

--- a/src/Compilers/Lua/CommandLine/TimingLoggerConsole.cs
+++ b/src/Compilers/Lua/CommandLine/TimingLoggerConsole.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.CommandLine;
+﻿using System.CommandLine;
 using System.CommandLine.IO;
 using Tsu.Timing;
 

--- a/src/Compilers/Lua/Experimental/ConstantFolder.ExpressionFlags.cs
+++ b/src/Compilers/Lua/Experimental/ConstantFolder.ExpressionFlags.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Loretta.CodeAnalysis.Lua.Syntax;
-using Loretta.Utilities;
+﻿using Loretta.CodeAnalysis.Lua.Syntax;
 
 namespace Loretta.CodeAnalysis.Lua.Experimental
 {

--- a/src/Compilers/Lua/Experimental/ConstantFolder.cs
+++ b/src/Compilers/Lua/Experimental/ConstantFolder.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
+﻿using System.ComponentModel;
 using Loretta.CodeAnalysis.Lua.Syntax;
-using Loretta.Utilities;
 using static Loretta.CodeAnalysis.Lua.SyntaxFactory;
 
 namespace Loretta.CodeAnalysis.Lua.Experimental

--- a/src/Compilers/Lua/Experimental/Loretta.CodeAnalysis.Lua.Experimental.csproj
+++ b/src/Compilers/Lua/Experimental/Loretta.CodeAnalysis.Lua.Experimental.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$(MSBuildThisFileDirectory)../../../../build/LibraryProject.props" />
 

--- a/src/Compilers/Lua/Experimental/Loretta.CodeAnalysis.Lua.Experimental.csproj
+++ b/src/Compilers/Lua/Experimental/Loretta.CodeAnalysis.Lua.Experimental.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="../../../../build/LibraryProject.props" />
+  <Import Project="$(MSBuildThisFileDirectory)../../../../build/LibraryProject.props" />
 
   <!-- Package data -->
   <PropertyGroup>

--- a/src/Compilers/Lua/Experimental/LuaExtensions.cs
+++ b/src/Compilers/Lua/Experimental/LuaExtensions.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Immutable;
-
-namespace Loretta.CodeAnalysis.Lua.Experimental
+﻿namespace Loretta.CodeAnalysis.Lua.Experimental
 {
     /// <summary>
     /// The extension methods for 

--- a/src/Compilers/Lua/Experimental/Minifying/MinifyingUtils.cs
+++ b/src/Compilers/Lua/Experimental/Minifying/MinifyingUtils.cs
@@ -1,9 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using Loretta.Utilities;
-
-namespace Loretta.CodeAnalysis.Lua.Experimental.Minifying
+﻿namespace Loretta.CodeAnalysis.Lua.Experimental.Minifying
 {
     /// <summary>
     /// A class with helper methods for minifying.

--- a/src/Compilers/Lua/Experimental/Minifying/NamingStrategies.cs
+++ b/src/Compilers/Lua/Experimental/Minifying/NamingStrategies.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Text;
-using Loretta.Utilities;
+﻿using System.Text;
 
 namespace Loretta.CodeAnalysis.Lua.Experimental.Minifying
 {

--- a/src/Compilers/Lua/Experimental/Minifying/NamingStrategy.cs
+++ b/src/Compilers/Lua/Experimental/Minifying/NamingStrategy.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Loretta.CodeAnalysis.Lua.Experimental.Minifying
+﻿namespace Loretta.CodeAnalysis.Lua.Experimental.Minifying
 {
     /// <summary>
     /// The naming strategy to use to convert a slot into a variable

--- a/src/Compilers/Lua/Experimental/Minifying/RenamingRewriter.RenameTable.cs
+++ b/src/Compilers/Lua/Experimental/Minifying/RenamingRewriter.RenameTable.cs
@@ -1,8 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using Loretta.Utilities;
-
-namespace Loretta.CodeAnalysis.Lua.Experimental.Minifying
+﻿namespace Loretta.CodeAnalysis.Lua.Experimental.Minifying
 {
     internal partial class RenamingRewriter
     {

--- a/src/Compilers/Lua/Experimental/Minifying/RenamingRewriter.cs
+++ b/src/Compilers/Lua/Experimental/Minifying/RenamingRewriter.cs
@@ -1,5 +1,4 @@
 ﻿using Loretta.CodeAnalysis.Lua.Syntax;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Lua.Experimental.Minifying
 {

--- a/src/Compilers/Lua/Experimental/Minifying/SequentialSlotAllocator.cs
+++ b/src/Compilers/Lua/Experimental/Minifying/SequentialSlotAllocator.cs
@@ -1,6 +1,4 @@
-﻿using System.Threading;
-
-namespace Loretta.CodeAnalysis.Lua.Experimental.Minifying
+﻿namespace Loretta.CodeAnalysis.Lua.Experimental.Minifying
 {
     /// <summary>
     /// A sequential slot allocator.

--- a/src/Compilers/Lua/Experimental/Minifying/SortedSlotAllocator.cs
+++ b/src/Compilers/Lua/Experimental/Minifying/SortedSlotAllocator.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-namespace Loretta.CodeAnalysis.Lua.Experimental.Minifying
+﻿namespace Loretta.CodeAnalysis.Lua.Experimental.Minifying
 {
     /// <summary>
     /// The sorted slot allocator.

--- a/src/Compilers/Lua/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/Lua/Portable/Errors/ErrorFacts.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Globalization;
-using System.Threading;
-using Loretta.Utilities;
+﻿using System.Globalization;
 
 namespace Loretta.CodeAnalysis.Lua
 {

--- a/src/Compilers/Lua/Portable/Errors/LuaDiagnostic.cs
+++ b/src/Compilers/Lua/Portable/Errors/LuaDiagnostic.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Loretta.CodeAnalysis.Lua
+﻿namespace Loretta.CodeAnalysis.Lua
 {
     internal sealed class LuaDiagnostic : DiagnosticWithInfo
     {

--- a/src/Compilers/Lua/Portable/Errors/MessageProvider.cs
+++ b/src/Compilers/Lua/Portable/Errors/MessageProvider.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Globalization;
-using Loretta.Utilities;
+﻿using System.Globalization;
 
 namespace Loretta.CodeAnalysis.Lua
 {

--- a/src/Compilers/Lua/Portable/Errors/SyntaxDiagnosticInfo.cs
+++ b/src/Compilers/Lua/Portable/Errors/SyntaxDiagnosticInfo.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using Loretta.Utilities;
-
-namespace Loretta.CodeAnalysis.Lua
+﻿namespace Loretta.CodeAnalysis.Lua
 {
     internal class SyntaxDiagnosticInfo : DiagnosticInfo
     {

--- a/src/Compilers/Lua/Portable/Loretta.CodeAnalysis.Lua.csproj
+++ b/src/Compilers/Lua/Portable/Loretta.CodeAnalysis.Lua.csproj
@@ -13,6 +13,7 @@
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="Loretta.CodeAnalysis.Test.Utilities" />
     <InternalsVisibleTo Include="Loretta.CodeAnalysis.Lua.Test.Utilities" />

--- a/src/Compilers/Lua/Portable/Loretta.CodeAnalysis.Lua.csproj
+++ b/src/Compilers/Lua/Portable/Loretta.CodeAnalysis.Lua.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="../../../../build/LibraryProject.props" />
+  <Import Project="$(MSBuildThisFileDirectory)../../../../build/LibraryProject.props" />
 
   <!-- Package data -->
   <PropertyGroup>

--- a/src/Compilers/Lua/Portable/LuaExtensions.cs
+++ b/src/Compilers/Lua/Portable/LuaExtensions.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Threading;
+﻿using System.Diagnostics.CodeAnalysis;
 using Loretta.CodeAnalysis.Lua;
 using Loretta.CodeAnalysis.Syntax;
 

--- a/src/Compilers/Lua/Portable/LuaParseOptions.cs
+++ b/src/Compilers/Lua/Portable/LuaParseOptions.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using Loretta.CodeAnalysis.PooledObjects;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Lua
 {

--- a/src/Compilers/Lua/Portable/LuaSyntaxOptions.cs
+++ b/src/Compilers/Lua/Portable/LuaSyntaxOptions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Immutable;
-using Tsu;
+﻿using Tsu;
 
 namespace Loretta.CodeAnalysis.Lua
 {

--- a/src/Compilers/Lua/Portable/Parser/AbstractLexer.cs
+++ b/src/Compilers/Lua/Portable/Parser/AbstractLexer.cs
@@ -1,7 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Text;
+﻿using System.Text;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {

--- a/src/Compilers/Lua/Portable/Parser/Blender.Cursor.cs
+++ b/src/Compilers/Lua/Portable/Parser/Blender.Cursor.cs
@@ -3,8 +3,6 @@
 
 #nullable disable
 
-using Loretta.Utilities;
-
 namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {
     internal partial struct Blender

--- a/src/Compilers/Lua/Portable/Parser/Blender.Reader.cs
+++ b/src/Compilers/Lua/Portable/Parser/Blender.Reader.cs
@@ -3,9 +3,7 @@
 
 #nullable disable
 
-using System.Collections.Immutable;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {

--- a/src/Compilers/Lua/Portable/Parser/Blender.cs
+++ b/src/Compilers/Lua/Portable/Parser/Blender.cs
@@ -3,11 +3,7 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {

--- a/src/Compilers/Lua/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/Lua/Portable/Parser/LanguageParser.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
+﻿using Loretta.CodeAnalysis.Text;
 
 namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {

--- a/src/Compilers/Lua/Portable/Parser/Lexer.Numbers.cs
+++ b/src/Compilers/Lua/Portable/Parser/Lexer.Numbers.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Loretta.CodeAnalysis.Lua.Utilities;
 

--- a/src/Compilers/Lua/Portable/Parser/Lexer.ShortString.cs
+++ b/src/Compilers/Lua/Portable/Parser/Lexer.ShortString.cs
@@ -1,5 +1,4 @@
 ﻿using Loretta.CodeAnalysis.Lua.Utilities;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {

--- a/src/Compilers/Lua/Portable/Parser/Lexer.cs
+++ b/src/Compilers/Lua/Portable/Parser/Lexer.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Loretta.CodeAnalysis.Lua.Utilities;
 using Loretta.CodeAnalysis.Syntax.InternalSyntax;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {

--- a/src/Compilers/Lua/Portable/Parser/LexerCache.cs
+++ b/src/Compilers/Lua/Portable/Parser/LexerCache.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using Loretta.CodeAnalysis.PooledObjects;
-using Loretta.Utilities;
+﻿using Loretta.CodeAnalysis.PooledObjects;
 
 namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {

--- a/src/Compilers/Lua/Portable/Parser/SourceTextReader.cs
+++ b/src/Compilers/Lua/Portable/Parser/SourceTextReader.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Buffers;
+﻿using System.Buffers;
 using Loretta.CodeAnalysis.Text;
 
 namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax

--- a/src/Compilers/Lua/Portable/Parser/SyntaxParser.cs
+++ b/src/Compilers/Lua/Portable/Parser/SyntaxParser.cs
@@ -3,10 +3,6 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
 using Loretta.CodeAnalysis.PooledObjects;
 using Loretta.CodeAnalysis.Text;
 

--- a/src/Compilers/Lua/Portable/Scoping/IFunctionScope.cs
+++ b/src/Compilers/Lua/Portable/Scoping/IFunctionScope.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using Loretta.Utilities;
+﻿using System.Runtime.CompilerServices;
 
 namespace Loretta.CodeAnalysis.Lua
 {

--- a/src/Compilers/Lua/Portable/Scoping/IGotoLabel.cs
+++ b/src/Compilers/Lua/Portable/Scoping/IGotoLabel.cs
@@ -1,7 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using Loretta.CodeAnalysis.Lua.Syntax;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Lua
 {

--- a/src/Compilers/Lua/Portable/Scoping/IScope.cs
+++ b/src/Compilers/Lua/Portable/Scoping/IScope.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Loretta.CodeAnalysis.Lua.Syntax;
 using Loretta.CodeAnalysis.Lua.Utilities;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Lua
 {

--- a/src/Compilers/Lua/Portable/Scoping/IVariable.cs
+++ b/src/Compilers/Lua/Portable/Scoping/IVariable.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using Loretta.Utilities;
+﻿using System.Runtime.CompilerServices;
 
 namespace Loretta.CodeAnalysis.Lua
 {

--- a/src/Compilers/Lua/Portable/Script/ScopeAndVariableManager.BaseWalker.cs
+++ b/src/Compilers/Lua/Portable/Script/ScopeAndVariableManager.BaseWalker.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using Loretta.Utilities;
-
-namespace Loretta.CodeAnalysis.Lua
+﻿namespace Loretta.CodeAnalysis.Lua
 {
     internal partial class ScopeAndVariableManager
     {

--- a/src/Compilers/Lua/Portable/Script/ScopeAndVariableManager.GotoLabelWalker.cs
+++ b/src/Compilers/Lua/Portable/Script/ScopeAndVariableManager.GotoLabelWalker.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using Loretta.CodeAnalysis.Lua.Syntax;
-using Loretta.Utilities;
+﻿using Loretta.CodeAnalysis.Lua.Syntax;
 
 namespace Loretta.CodeAnalysis.Lua
 {

--- a/src/Compilers/Lua/Portable/Script/ScopeAndVariableManager.GotoWalker.cs
+++ b/src/Compilers/Lua/Portable/Script/ScopeAndVariableManager.GotoWalker.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using Loretta.CodeAnalysis.Lua.Syntax;
-using Loretta.Utilities;
+﻿using Loretta.CodeAnalysis.Lua.Syntax;
 
 namespace Loretta.CodeAnalysis.Lua
 {

--- a/src/Compilers/Lua/Portable/Script/ScopeAndVariableManager.ScopeAndVariableWalker.cs
+++ b/src/Compilers/Lua/Portable/Script/ScopeAndVariableManager.ScopeAndVariableWalker.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Loretta.CodeAnalysis.Lua.Syntax;
-using Loretta.Utilities;
+﻿using Loretta.CodeAnalysis.Lua.Syntax;
 
 namespace Loretta.CodeAnalysis.Lua
 {

--- a/src/Compilers/Lua/Portable/Script/ScopeAndVariableManager.State.cs
+++ b/src/Compilers/Lua/Portable/Script/ScopeAndVariableManager.State.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Immutable;
-
-namespace Loretta.CodeAnalysis.Lua
+﻿namespace Loretta.CodeAnalysis.Lua
 {
     internal partial class ScopeAndVariableManager
     {

--- a/src/Compilers/Lua/Portable/Script/ScopeAndVariableManager.cs
+++ b/src/Compilers/Lua/Portable/Script/ScopeAndVariableManager.cs
@@ -1,8 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Threading;
-
-namespace Loretta.CodeAnalysis.Lua
+﻿namespace Loretta.CodeAnalysis.Lua
 {
     internal partial class ScopeAndVariableManager
     {

--- a/src/Compilers/Lua/Portable/Script/Script.RenameRewriter.cs
+++ b/src/Compilers/Lua/Portable/Script/Script.RenameRewriter.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Loretta.CodeAnalysis.Lua.Syntax;
+﻿using Loretta.CodeAnalysis.Lua.Syntax;
 
 namespace Loretta.CodeAnalysis.Lua
 {

--- a/src/Compilers/Lua/Portable/Script/Script.cs
+++ b/src/Compilers/Lua/Portable/Script/Script.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using Tsu;
+﻿using Tsu;
 
 namespace Loretta.CodeAnalysis.Lua
 {

--- a/src/Compilers/Lua/Portable/SymbolDisplay/ObjectDisplay.cs
+++ b/src/Compilers/Lua/Portable/SymbolDisplay/ObjectDisplay.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Loretta.CodeAnalysis.Lua.Utilities;
 using Loretta.CodeAnalysis.PooledObjects;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Lua.SymbolDisplay
 {

--- a/src/Compilers/Lua/Portable/Syntax/InternalSyntax/LuaSyntaxNode.cs
+++ b/src/Compilers/Lua/Portable/Syntax/InternalSyntax/LuaSyntaxNode.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using Loretta.CodeAnalysis.Syntax.InternalSyntax;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {

--- a/src/Compilers/Lua/Portable/Syntax/InternalSyntax/LuaSyntaxWalker.cs
+++ b/src/Compilers/Lua/Portable/Syntax/InternalSyntax/LuaSyntaxWalker.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
+﻿namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {
     internal class LuaSyntaxWalker : LuaSyntaxVisitor
     {

--- a/src/Compilers/Lua/Portable/Syntax/InternalSyntax/StructuredTriviaSyntax.cs
+++ b/src/Compilers/Lua/Portable/Syntax/InternalSyntax/StructuredTriviaSyntax.cs
@@ -1,6 +1,4 @@
-﻿using Loretta.Utilities;
-
-namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
+﻿namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {
     internal abstract partial class StructuredTriviaSyntax : LuaSyntaxNode
     {

--- a/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxFactory.cs
+++ b/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxFactory.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using Loretta.Utilities;
-
-namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
+﻿namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {
     internal static partial class SyntaxFactory
     {

--- a/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxToken.MissingTokenWithTrivia.cs
+++ b/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxToken.MissingTokenWithTrivia.cs
@@ -1,6 +1,4 @@
-﻿using Loretta.Utilities;
-
-namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
+﻿namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {
     internal partial class SyntaxToken
     {

--- a/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxToken.SyntaxIdentifier.cs
+++ b/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxToken.SyntaxIdentifier.cs
@@ -1,6 +1,4 @@
-﻿using Loretta.Utilities;
-
-namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
+﻿namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {
     internal partial class SyntaxToken
     {

--- a/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxToken.SyntaxIdentifierExtended.cs
+++ b/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxToken.SyntaxIdentifierExtended.cs
@@ -1,6 +1,4 @@
-﻿using Loretta.Utilities;
-
-namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
+﻿namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {
     internal partial class SyntaxToken
     {

--- a/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxToken.SyntaxIdentifierWithTrailingTrivia.cs
+++ b/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxToken.SyntaxIdentifierWithTrailingTrivia.cs
@@ -1,6 +1,4 @@
-﻿using Loretta.Utilities;
-
-namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
+﻿namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {
     internal partial class SyntaxToken
     {

--- a/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxToken.SyntaxIdentifierWithTrivia.cs
+++ b/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxToken.SyntaxIdentifierWithTrivia.cs
@@ -1,6 +1,4 @@
-﻿using Loretta.Utilities;
-
-namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
+﻿namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {
     internal partial class SyntaxToken
     {

--- a/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxToken.SyntaxTokenWithTrivia.cs
+++ b/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxToken.SyntaxTokenWithTrivia.cs
@@ -1,6 +1,4 @@
-﻿using Loretta.Utilities;
-
-namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
+﻿namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {
     internal partial class SyntaxToken
     {

--- a/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxToken.SyntaxTokenWithValue.cs
+++ b/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxToken.SyntaxTokenWithValue.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using Loretta.Utilities;
-
-namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
+﻿namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {
     using System.Globalization;
 

--- a/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxToken.SyntaxTokenWithValueAndTrivia.cs
+++ b/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxToken.SyntaxTokenWithValueAndTrivia.cs
@@ -1,6 +1,4 @@
-﻿using Loretta.Utilities;
-
-namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
+﻿namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {
     internal partial class SyntaxToken
     {

--- a/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxToken.cs
+++ b/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxToken.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Loretta.Utilities;
-
-namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
+﻿namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {
     using Loretta.CodeAnalysis.Syntax.InternalSyntax;
 

--- a/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxTrivia.cs
+++ b/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxTrivia.cs
@@ -1,6 +1,4 @@
-﻿using Loretta.Utilities;
-
-namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
+﻿namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {
     internal class SyntaxTrivia : LuaSyntaxNode
     {

--- a/src/Compilers/Lua/Portable/Syntax/LuaSyntaxNode.cs
+++ b/src/Compilers/Lua/Portable/Syntax/LuaSyntaxNode.cs
@@ -1,11 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading;
-using Loretta.CodeAnalysis.Lua.Syntax;
+﻿using Loretta.CodeAnalysis.Lua.Syntax;
 using Loretta.CodeAnalysis.PooledObjects;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Lua
 {

--- a/src/Compilers/Lua/Portable/Syntax/LuaSyntaxRewriter.cs
+++ b/src/Compilers/Lua/Portable/Syntax/LuaSyntaxRewriter.cs
@@ -1,11 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using Loretta.CodeAnalysis.Lua.Syntax;
 using Loretta.CodeAnalysis.Syntax;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Lua
 {

--- a/src/Compilers/Lua/Portable/Syntax/LuaSyntaxTree.DummySyntaxTree.cs
+++ b/src/Compilers/Lua/Portable/Syntax/LuaSyntaxTree.DummySyntaxTree.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text;
-using System.Threading;
 using Loretta.CodeAnalysis.Lua.Syntax;
 using Loretta.CodeAnalysis.Text;
 

--- a/src/Compilers/Lua/Portable/Syntax/LuaSyntaxTree.ParsedSyntaxTree.cs
+++ b/src/Compilers/Lua/Portable/Syntax/LuaSyntaxTree.ParsedSyntaxTree.cs
@@ -3,9 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
-using System.Threading;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Lua
 {

--- a/src/Compilers/Lua/Portable/Syntax/LuaSyntaxTree.cs
+++ b/src/Compilers/Lua/Portable/Syntax/LuaSyntaxTree.cs
@@ -1,15 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Loretta.CodeAnalysis.Lua.Syntax;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 using InternalSyntax = Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax;
 
 namespace Loretta.CodeAnalysis.Lua

--- a/src/Compilers/Lua/Portable/Syntax/LuaTreeDumperConverter.cs
+++ b/src/Compilers/Lua/Portable/Syntax/LuaTreeDumperConverter.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Loretta.CodeAnalysis.Lua.SymbolDisplay;
-using Loretta.Utilities;
+﻿using Loretta.CodeAnalysis.Lua.SymbolDisplay;
 
 namespace Loretta.CodeAnalysis.Lua.Syntax
 {

--- a/src/Compilers/Lua/Portable/Syntax/SimpleSyntaxReference.cs
+++ b/src/Compilers/Lua/Portable/Syntax/SimpleSyntaxReference.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Threading;
 using Loretta.CodeAnalysis.Text;
 
 namespace Loretta.CodeAnalysis.Lua

--- a/src/Compilers/Lua/Portable/Syntax/StructuredTriviaSyntax.cs
+++ b/src/Compilers/Lua/Portable/Syntax/StructuredTriviaSyntax.cs
@@ -1,6 +1,4 @@
-﻿using Loretta.Utilities;
-
-namespace Loretta.CodeAnalysis.Lua.Syntax
+﻿namespace Loretta.CodeAnalysis.Lua.Syntax
 {
     /// <summary>
     /// It's a non terminal Trivia CSharpSyntaxNode that has a tree underneath it.

--- a/src/Compilers/Lua/Portable/Syntax/SyntaxEquivalence.cs
+++ b/src/Compilers/Lua/Portable/Syntax/SyntaxEquivalence.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using Loretta.Utilities;
-
 namespace Loretta.CodeAnalysis.Lua.Syntax
 {
     using Green = InternalSyntax;

--- a/src/Compilers/Lua/Portable/Syntax/SyntaxExtensions.cs
+++ b/src/Compilers/Lua/Portable/Syntax/SyntaxExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Loretta.CodeAnalysis.Lua.Syntax;
+﻿using Loretta.CodeAnalysis.Lua.Syntax;
 
 namespace Loretta.CodeAnalysis.Lua
 {

--- a/src/Compilers/Lua/Portable/Syntax/SyntaxFactory.cs
+++ b/src/Compilers/Lua/Portable/Syntax/SyntaxFactory.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
+﻿using System.Text;
 using Loretta.CodeAnalysis.Lua.SymbolDisplay;
 using Loretta.CodeAnalysis.Lua.Syntax;
 using Loretta.CodeAnalysis.Syntax;

--- a/src/Compilers/Lua/Portable/Syntax/SyntaxFacts.cs
+++ b/src/Compilers/Lua/Portable/Syntax/SyntaxFacts.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Tsu;
+﻿using Tsu;
 
 namespace Loretta.CodeAnalysis.Lua
 {

--- a/src/Compilers/Lua/Portable/Syntax/SyntaxKind.cs
+++ b/src/Compilers/Lua/Portable/Syntax/SyntaxKind.cs
@@ -1,6 +1,5 @@
 ﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member (still not sure of how to document this)
 
-using System;
 using System.ComponentModel;
 
 namespace Loretta.CodeAnalysis.Lua

--- a/src/Compilers/Lua/Portable/Syntax/SyntaxKindEqualityComparer.cs
+++ b/src/Compilers/Lua/Portable/Syntax/SyntaxKindEqualityComparer.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-
 namespace Loretta.CodeAnalysis.Lua
 {
     public static partial class SyntaxFacts

--- a/src/Compilers/Lua/Portable/Syntax/SyntaxNodeRemover.cs
+++ b/src/Compilers/Lua/Portable/Syntax/SyntaxNodeRemover.cs
@@ -1,13 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Loretta.CodeAnalysis.Syntax;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Lua.Syntax
 {

--- a/src/Compilers/Lua/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/Lua/Portable/Syntax/SyntaxNormalizer.cs
@@ -1,11 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.Linq;
 using Loretta.CodeAnalysis.PooledObjects;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Lua.Syntax
 {

--- a/src/Compilers/Lua/Portable/Syntax/SyntaxReplacer.cs
+++ b/src/Compilers/Lua/Portable/Syntax/SyntaxReplacer.cs
@@ -1,12 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Lua.Syntax
 {

--- a/src/Compilers/Lua/Portable/Syntax/SyntaxTreeDiagnosticEnumerator.cs
+++ b/src/Compilers/Lua/Portable/Syntax/SyntaxTreeDiagnosticEnumerator.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using Loretta.CodeAnalysis.Text;
-using Loretta.Utilities;
 
 namespace Loretta.CodeAnalysis.Lua
 {

--- a/src/Compilers/Lua/Portable/Utilities/CharUtils.cs
+++ b/src/Compilers/Lua/Portable/Utilities/CharUtils.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Globalization;
-using System.Linq;
+﻿using System.Globalization;
 using System.Runtime.CompilerServices;
 
 namespace Loretta.CodeAnalysis.Lua.Utilities

--- a/src/Compilers/Lua/Portable/Utilities/HexFloat.cs
+++ b/src/Compilers/Lua/Portable/Utilities/HexFloat.cs
@@ -4,8 +4,6 @@
 // brevity. 32-bit floating point related code was also removed since it was not relevant to this
 // project. Unsafe code was removed as well.
 
-using System;
-
 namespace Loretta.CodeAnalysis.Lua.Utilities
 {
     internal static class HexFloat

--- a/src/Compilers/Lua/Portable/Utilities/StringUtils.cs
+++ b/src/Compilers/Lua/Portable/Utilities/StringUtils.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Loretta.CodeAnalysis.Lua.Utilities
+﻿namespace Loretta.CodeAnalysis.Lua.Utilities
 {
     /// <summary>
     /// A class with utilities for strings.

--- a/src/Compilers/Lua/Test/Portable/Lexical/LexicalTestData.cs
+++ b/src/Compilers/Lua/Test/Portable/Lexical/LexicalTestData.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Globalization;
-using System.Linq;
+﻿using System.Globalization;
 using Loretta.CodeAnalysis.Lua.Utilities;
 using Loretta.CodeAnalysis.Text;
 using static Tsu.Option;
@@ -138,7 +134,7 @@ fourth line \xFF.";
             yield return new ShortToken(
                 SyntaxKind.HashStringLiteralToken,
                 $"`{shortStringContentText}`",
-                Loretta.Utilities.Hash.GetJenkinsOneAtATimeHashCode(shortStringContentValue.AsSpan()));
+                Hash.GetJenkinsOneAtATimeHashCode(shortStringContentValue.AsSpan()));
 
             #endregion Strings
 

--- a/src/Compilers/Lua/Test/Portable/Lexical/LexicalTests.cs
+++ b/src/Compilers/Lua/Test/Portable/Lexical/LexicalTests.cs
@@ -1,8 +1,4 @@
 ﻿//#define LARGE_TESTS_DEBUG
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
 using Loretta.CodeAnalysis.Lua.UnitTests.Parsing;
 using Loretta.CodeAnalysis.Text;
 using Loretta.Test.Utilities;

--- a/src/Compilers/Lua/Test/Portable/Lexical/RunLongLexerTests.cs
+++ b/src/Compilers/Lua/Test/Portable/Lexical/RunLongLexerTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Loretta.Test.Utilities;
+﻿using Loretta.Test.Utilities;
 
 namespace Loretta.CodeAnalysis.Lua.UnitTests.Lexical
 {

--- a/src/Compilers/Lua/Test/Portable/Loretta.CodeAnalysis.Lua.UnitTests.csproj
+++ b/src/Compilers/Lua/Test/Portable/Loretta.CodeAnalysis.Lua.UnitTests.csproj
@@ -11,6 +11,11 @@
     <TargetFrameworks Condition="'$(IsUnusedAnalysis)' == 'true'">net5.0</TargetFrameworks>
   </PropertyGroup>
 
+  <!-- Implicit Usings -->
+  <ItemGroup>
+    <Using Include="Loretta.Utilities" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Tsu" Version="2.1.1" />

--- a/src/Compilers/Lua/Test/Portable/Loretta.CodeAnalysis.Lua.UnitTests.csproj
+++ b/src/Compilers/Lua/Test/Portable/Loretta.CodeAnalysis.Lua.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$(MSBuildThisFileDirectory)../../../../../build/BaseProject.props" />
-  
+
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <TargetFrameworks>net472</TargetFrameworks>
   </PropertyGroup>
@@ -9,9 +9,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworks);net5.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(IsUnusedAnalysis)' == 'true'">net5.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <IsPackable>false</IsPackable>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Compilers/Lua/Test/Portable/Loretta.CodeAnalysis.Lua.UnitTests.csproj
+++ b/src/Compilers/Lua/Test/Portable/Loretta.CodeAnalysis.Lua.UnitTests.csproj
@@ -1,5 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$(MSBuildThisFileDirectory)../../../../../build/BaseProject.props" />
+  
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <TargetFrameworks>net472</TargetFrameworks>
   </PropertyGroup>
@@ -23,6 +25,10 @@
     <PackageReference Include="coverlet.collector" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0-2.22114.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 

--- a/src/Compilers/Lua/Test/Portable/Parsing/ParsingTestsBase.cs
+++ b/src/Compilers/Lua/Test/Portable/Parsing/ParsingTestsBase.cs
@@ -1,10 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using Loretta.CodeAnalysis.Lua.Syntax;
 using Loretta.CodeAnalysis.Lua.Test.Utilities;
 using Loretta.CodeAnalysis.Test.Utilities;

--- a/src/Compilers/Lua/Test/Portable/Parsing/SyntaxExtensions.cs
+++ b/src/Compilers/Lua/Test/Portable/Parsing/SyntaxExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Immutable;
-using Loretta.CodeAnalysis.PooledObjects;
+﻿using Loretta.CodeAnalysis.PooledObjects;
 using Loretta.CodeAnalysis.Syntax.InternalSyntax;
 
 namespace Loretta.CodeAnalysis.Lua.UnitTests.Parsing

--- a/src/Compilers/Lua/Test/Portable/Scoping/FindScopeTests.cs
+++ b/src/Compilers/Lua/Test/Portable/Scoping/FindScopeTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using Loretta.CodeAnalysis.Lua.Syntax;
+﻿using Loretta.CodeAnalysis.Lua.Syntax;
 using Xunit;
 
 namespace Loretta.CodeAnalysis.Lua.UnitTests.Scoping

--- a/src/Compilers/Lua/Test/Portable/Scoping/FindVariableTests.cs
+++ b/src/Compilers/Lua/Test/Portable/Scoping/FindVariableTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using Loretta.CodeAnalysis.Lua.Syntax;
+﻿using Loretta.CodeAnalysis.Lua.Syntax;
 using Xunit;
 
 namespace Loretta.CodeAnalysis.Lua.UnitTests.Scoping

--- a/src/Compilers/Lua/Test/Portable/Scoping/RenameVariableTests.cs
+++ b/src/Compilers/Lua/Test/Portable/Scoping/RenameVariableTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using Xunit;
+﻿using Xunit;
 
 namespace Loretta.CodeAnalysis.Lua.UnitTests.Scoping
 {

--- a/src/Compilers/Lua/Test/Portable/Scoping/ScriptTestsBase.cs
+++ b/src/Compilers/Lua/Test/Portable/Scoping/ScriptTestsBase.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Collections.Immutable;
-using Loretta.CodeAnalysis.Lua.Test.Utilities;
+﻿using Loretta.CodeAnalysis.Lua.Test.Utilities;
 
 namespace Loretta.CodeAnalysis.Lua.UnitTests.Scoping
 {

--- a/src/Compilers/Lua/Test/Portable/SyntaxKindTests.cs
+++ b/src/Compilers/Lua/Test/Portable/SyntaxKindTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using Xunit;
+﻿using Xunit;
 
 namespace Loretta.CodeAnalysis.Lua.UnitTests.Syntax
 {

--- a/src/Compilers/Lua/Test/Utilities/AssertEx.cs
+++ b/src/Compilers/Lua/Test/Utilities/AssertEx.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Xunit.Sdk;
+﻿using Xunit.Sdk;
 
 namespace Loretta.CodeAnalysis.Lua.Test.Utilities
 {

--- a/src/Compilers/Lua/Test/Utilities/Loretta.CodeAnalysis.Lua.Test.Utilities.csproj
+++ b/src/Compilers/Lua/Test/Utilities/Loretta.CodeAnalysis.Lua.Test.Utilities.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$(MSBuildThisFileDirectory)../../../../../build/BaseProject.props" />
+
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net5.0;netcoreapp3.1;netstandard2.0;net472</TargetFrameworks>

--- a/src/Compilers/Lua/Test/Utilities/Loretta.CodeAnalysis.Lua.Test.Utilities.csproj
+++ b/src/Compilers/Lua/Test/Utilities/Loretta.CodeAnalysis.Lua.Test.Utilities.csproj
@@ -6,8 +6,6 @@
     <OutputType>Library</OutputType>
     <TargetFrameworks>net5.0;netcoreapp3.1;netstandard2.0;net472</TargetFrameworks>
     <TargetFrameworks Condition="'$(IsUnusedAnalysis)' == 'true'">net5.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Compilers/Lua/Test/Utilities/Loretta.CodeAnalysis.Lua.Test.Utilities.csproj
+++ b/src/Compilers/Lua/Test/Utilities/Loretta.CodeAnalysis.Lua.Test.Utilities.csproj
@@ -8,6 +8,11 @@
     <TargetFrameworks Condition="'$(IsUnusedAnalysis)' == 'true'">net5.0</TargetFrameworks>
   </PropertyGroup>
 
+  <!-- Implicit Usings -->
+  <ItemGroup>
+    <Using Include="Loretta.Utilities" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\Core\Portable\Loretta.CodeAnalysis.csproj" />
     <ProjectReference Include="..\..\..\Core\Test\Utilities\Loretta.CodeAnalysis.Test.Utilities.csproj" />

--- a/src/Compilers/Lua/Test/Utilities/LuaTestBase.cs
+++ b/src/Compilers/Lua/Test/Utilities/LuaTestBase.cs
@@ -4,10 +4,6 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Text;
 using Loretta.CodeAnalysis;
 using Loretta.CodeAnalysis.Test.Utilities;

--- a/src/Compilers/Lua/Test/Utilities/LuaTestSource.cs
+++ b/src/Compilers/Lua/Test/Utilities/LuaTestSource.cs
@@ -3,11 +3,7 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
 
 namespace Loretta.CodeAnalysis.Lua.Test.Utilities
 {

--- a/src/Compilers/Lua/Test/Utilities/RandomSpaceInserter.cs
+++ b/src/Compilers/Lua/Test/Utilities/RandomSpaceInserter.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Text;
 
 namespace Loretta.CodeAnalysis.Lua.Test.Utilities
 {

--- a/src/Compilers/Lua/Test/Utilities/RandomSpaceInserterDataAttribute.cs
+++ b/src/Compilers/Lua/Test/Utilities/RandomSpaceInserterDataAttribute.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Reflection;
 using Xunit.Sdk;
 
 namespace Loretta.CodeAnalysis.Lua.Test.Utilities

--- a/src/Compilers/Lua/Test/Utilities/SyntaxTreeExtensions.cs
+++ b/src/Compilers/Lua/Test/Utilities/SyntaxTreeExtensions.cs
@@ -4,7 +4,6 @@
 
 #nullable disable
 
-using System;
 using Loretta.CodeAnalysis.Lua.Syntax;
 using Loretta.CodeAnalysis.PooledObjects;
 using Loretta.CodeAnalysis.Text;

--- a/src/InternalBenchmarks/Loretta.InternalBenchmarks.csproj
+++ b/src/InternalBenchmarks/Loretta.InternalBenchmarks.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$(MSBuildThisFileDirectory)../../build/BaseProject.props" />
+  
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>

--- a/src/Tools/Analyzers/Loretta.Analyzers.csproj
+++ b/src/Tools/Analyzers/Loretta.Analyzers.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$(MSBuildThisFileDirectory)../../../build/BaseProject.props" />
+  
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>

--- a/src/Tools/Analyzers/Loretta.Analyzers.csproj
+++ b/src/Tools/Analyzers/Loretta.Analyzers.csproj
@@ -1,11 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$(MSBuildThisFileDirectory)../../../build/BaseProject.props" />
-  
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <IsPackable>false</IsPackable>
 
     <!-- Avoid ID conflicts with the package project. -->
     <PackageId>*$(MSBuildProjectFile)*</PackageId>

--- a/src/Tools/Loretta.Generators.ErrorFactsGenerator/Loretta.Generators.ErrorFactsGenerator.csproj
+++ b/src/Tools/Loretta.Generators.ErrorFactsGenerator/Loretta.Generators.ErrorFactsGenerator.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$(MSBuildThisFileDirectory)../../../build/BaseProject.props" />
+  
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>

--- a/src/Tools/Loretta.Generators.ErrorFactsGenerator/Loretta.Generators.ErrorFactsGenerator.csproj
+++ b/src/Tools/Loretta.Generators.ErrorFactsGenerator/Loretta.Generators.ErrorFactsGenerator.csproj
@@ -1,13 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$(MSBuildThisFileDirectory)../../../build/BaseProject.props" />
-  
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
-    <IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tools/Loretta.Generators.ErrorFactsGenerator/SourceGenerator.cs
+++ b/src/Tools/Loretta.Generators.ErrorFactsGenerator/SourceGenerator.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 
 namespace Loretta.Generators.ErrorCode
 {

--- a/src/Tools/Loretta.Generators.Shared/AdditionalTextCachingSourceGenerator.cs
+++ b/src/Tools/Loretta.Generators.Shared/AdditionalTextCachingSourceGenerator.cs
@@ -1,11 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 

--- a/src/Tools/Loretta.Generators.Shared/CurlyIndenter.cs
+++ b/src/Tools/Loretta.Generators.Shared/CurlyIndenter.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.CodeDom.Compiler;
+﻿using System.CodeDom.Compiler;
 
 namespace Loretta.Generators
 {

--- a/src/Tools/Loretta.Generators.Shared/GeneratorBase.cs
+++ b/src/Tools/Loretta.Generators.Shared/GeneratorBase.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.CodeDom.Compiler;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System.CodeDom.Compiler;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/Tools/Loretta.Generators.Shared/Indenter.cs
+++ b/src/Tools/Loretta.Generators.Shared/Indenter.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.CodeDom.Compiler;
+﻿using System.CodeDom.Compiler;
 
 namespace Loretta.Generators
 {

--- a/src/Tools/Loretta.Generators.Shared/OptimizedSwitch.cs
+++ b/src/Tools/Loretta.Generators.Shared/OptimizedSwitch.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Threading;
+﻿using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.CSharp;
 
 namespace Loretta.Generators

--- a/src/Tools/Loretta.Generators.Shared/SourceTextReader.cs
+++ b/src/Tools/Loretta.Generators.Shared/SourceTextReader.cs
@@ -3,8 +3,6 @@
 
 #nullable enable
 
-using System;
-using System.IO;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Loretta.Generators

--- a/src/Tools/Loretta.Generators.Shared/SourceWriter.cs
+++ b/src/Tools/Loretta.Generators.Shared/SourceWriter.cs
@@ -1,5 +1,4 @@
 ﻿using System.CodeDom.Compiler;
-using System.IO;
 using System.Text;
 using Microsoft.CodeAnalysis.Text;
 

--- a/src/Tools/Loretta.Generators.Shared/StringBuilderReader.cs
+++ b/src/Tools/Loretta.Generators.Shared/StringBuilderReader.cs
@@ -3,8 +3,6 @@
 
 #nullable enable
 
-using System;
-using System.IO;
 using System.Text;
 
 namespace Loretta.Generators

--- a/src/Tools/Loretta.Generators.Shared/Utilities.cs
+++ b/src/Tools/Loretta.Generators.Shared/Utilities.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Loretta.Generators

--- a/src/Tools/Loretta.Generators.SyntaxKindGenerator/KindInfo.cs
+++ b/src/Tools/Loretta.Generators.SyntaxKindGenerator/KindInfo.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 
 namespace Loretta.Generators.SyntaxKindGenerator
 {

--- a/src/Tools/Loretta.Generators.SyntaxKindGenerator/KindList.cs
+++ b/src/Tools/Loretta.Generators.SyntaxKindGenerator/KindList.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
+﻿using System.Collections;
 
 namespace Loretta.Generators.SyntaxKindGenerator
 {

--- a/src/Tools/Loretta.Generators.SyntaxKindGenerator/KindUtils.cs
+++ b/src/Tools/Loretta.Generators.SyntaxKindGenerator/KindUtils.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
+﻿using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/src/Tools/Loretta.Generators.SyntaxKindGenerator/Loretta.Generators.SyntaxKindGenerator.csproj
+++ b/src/Tools/Loretta.Generators.SyntaxKindGenerator/Loretta.Generators.SyntaxKindGenerator.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$(MSBuildThisFileDirectory)../../../build/BaseProject.props" />
+  
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>

--- a/src/Tools/Loretta.Generators.SyntaxKindGenerator/Loretta.Generators.SyntaxKindGenerator.csproj
+++ b/src/Tools/Loretta.Generators.SyntaxKindGenerator/Loretta.Generators.SyntaxKindGenerator.csproj
@@ -1,14 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$(MSBuildThisFileDirectory)../../../build/BaseProject.props" />
-  
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
-    <IsPublishable>false</IsPublishable>
-    <IsRoslynComponent>true</IsRoslynComponent>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tools/Loretta.Generators.SyntaxKindGenerator/SyntaxKindRelatedTypesGenerator.GenerateSyntaxFacts.cs
+++ b/src/Tools/Loretta.Generators.SyntaxKindGenerator/SyntaxKindRelatedTypesGenerator.GenerateSyntaxFacts.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;

--- a/src/Tools/Loretta.Generators.SyntaxKindGenerator/SyntaxKindRelatedTypesGenerator.cs
+++ b/src/Tools/Loretta.Generators.SyntaxKindGenerator/SyntaxKindRelatedTypesGenerator.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 
 namespace Loretta.Generators.SyntaxKindGenerator

--- a/src/Tools/Loretta.Generators.SyntaxXml/AbstractFileWriter.cs
+++ b/src/Tools/Loretta.Generators.SyntaxXml/AbstractFileWriter.cs
@@ -3,12 +3,6 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading;
-
 namespace Loretta.Generators.SyntaxXml
 {
     internal abstract class AbstractFileWriter

--- a/src/Tools/Loretta.Generators.SyntaxXml/AbstractFileWriter.cs
+++ b/src/Tools/Loretta.Generators.SyntaxXml/AbstractFileWriter.cs
@@ -105,10 +105,10 @@ namespace Loretta.Generators.SyntaxXml
         /// cref="IEnumerable{T}"/>s of <see cref="string"/>.  All of these are flattened into a
         /// single sequence that is joined. Empty strings are ignored.
         /// </summary>
-        protected string CommaJoin(params object[] values)
+        protected static string CommaJoin(params object[] values)
             => Join(", ", values);
 
-        protected string Join(string separator, params object[] values)
+        protected static string Join(string separator, params object[] values)
             => string.Join(separator, values.SelectMany(v => (v switch
             {
                 string s => new[] { s },

--- a/src/Tools/Loretta.Generators.SyntaxXml/Loretta.Generators.SyntaxXml.csproj
+++ b/src/Tools/Loretta.Generators.SyntaxXml/Loretta.Generators.SyntaxXml.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$(MSBuildThisFileDirectory)../../../build/BaseProject.props" />
+  
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>

--- a/src/Tools/Loretta.Generators.SyntaxXml/Loretta.Generators.SyntaxXml.csproj
+++ b/src/Tools/Loretta.Generators.SyntaxXml/Loretta.Generators.SyntaxXml.csproj
@@ -1,13 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$(MSBuildThisFileDirectory)../../../build/BaseProject.props" />
-  
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
-    <IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tools/Loretta.Generators.SyntaxXml/Model/AbstractNode.cs
+++ b/src/Tools/Loretta.Generators.SyntaxXml/Model/AbstractNode.cs
@@ -2,8 +2,6 @@
 
 #nullable disable
 
-using System.Collections.Generic;
-
 namespace Loretta.Generators.SyntaxXml
 {
     public class AbstractNode : TreeType

--- a/src/Tools/Loretta.Generators.SyntaxXml/Model/Field.cs
+++ b/src/Tools/Loretta.Generators.SyntaxXml/Model/Field.cs
@@ -2,7 +2,6 @@
 
 #nullable disable
 
-using System.Collections.Generic;
 using System.Xml.Serialization;
 
 namespace Loretta.Generators.SyntaxXml

--- a/src/Tools/Loretta.Generators.SyntaxXml/Model/Node.cs
+++ b/src/Tools/Loretta.Generators.SyntaxXml/Model/Node.cs
@@ -2,8 +2,6 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
 using System.Xml.Serialization;
 
 namespace Loretta.Generators.SyntaxXml

--- a/src/Tools/Loretta.Generators.SyntaxXml/Model/Tree.cs
+++ b/src/Tools/Loretta.Generators.SyntaxXml/Model/Tree.cs
@@ -2,7 +2,6 @@
 
 #nullable disable
 
-using System.Collections.Generic;
 using System.Xml.Serialization;
 
 namespace Loretta.Generators.SyntaxXml

--- a/src/Tools/Loretta.Generators.SyntaxXml/Model/TreeType.cs
+++ b/src/Tools/Loretta.Generators.SyntaxXml/Model/TreeType.cs
@@ -2,7 +2,6 @@
 
 #nullable disable
 
-using System.Collections.Generic;
 using System.Xml.Serialization;
 
 namespace Loretta.Generators.SyntaxXml

--- a/src/Tools/Loretta.Generators.SyntaxXml/SignatureWriter.cs
+++ b/src/Tools/Loretta.Generators.SyntaxXml/SignatureWriter.cs
@@ -3,11 +3,6 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-
 namespace Loretta.Generators.SyntaxXml
 {
     internal class SignatureWriter
@@ -106,9 +101,9 @@ namespace Loretta.Generators.SyntaxXml
             }
         }
 
-        private bool IsSeparatedNodeList(string typeName) => typeName.StartsWith("SeparatedSyntaxList<", StringComparison.Ordinal);
+        private static bool IsSeparatedNodeList(string typeName) => typeName.StartsWith("SeparatedSyntaxList<", StringComparison.Ordinal);
 
-        private bool IsNodeList(string typeName) => typeName.StartsWith("SyntaxList<", StringComparison.Ordinal);
+        private static bool IsNodeList(string typeName) => typeName.StartsWith("SyntaxList<", StringComparison.Ordinal);
 
         public bool IsNodeOrNodeList(string typeName) => IsNode(typeName) || IsNodeList(typeName) || IsSeparatedNodeList(typeName);
 

--- a/src/Tools/Loretta.Generators.SyntaxXml/SourceWriter.cs
+++ b/src/Tools/Loretta.Generators.SyntaxXml/SourceWriter.cs
@@ -3,12 +3,6 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading;
-
 namespace Loretta.Generators.SyntaxXml
 {
     internal class SourceWriter : AbstractFileWriter

--- a/src/Tools/Loretta.Generators.SyntaxXml/SyntaxXmlSourceGenerator.cs
+++ b/src/Tools/Loretta.Generators.SyntaxXml/SyntaxXmlSourceGenerator.cs
@@ -27,7 +27,6 @@ namespace Loretta.Generators.SyntaxXml
             category: "SyntaxGenerator",
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
-        [SuppressMessage("MicrosoftCodeAnalysisDesign", "RS1032:Define diagnostic message correctly", Justification = "It is a question mark.")]
         private static readonly DiagnosticDescriptor s_unableToReadSyntaxXml = new(
             "LSSG1002",
             title: "Syntax.xml could not be read",

--- a/src/Tools/Loretta.Generators.SyntaxXml/SyntaxXmlSourceGenerator.cs
+++ b/src/Tools/Loretta.Generators.SyntaxXml/SyntaxXmlSourceGenerator.cs
@@ -3,13 +3,8 @@
 
 #nullable enable
 
-using System;
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading;
 using System.Xml;
 using System.Xml.Serialization;
 using Microsoft.CodeAnalysis;

--- a/src/Tools/Loretta.Generators.SyntaxXml/TestWriter.cs
+++ b/src/Tools/Loretta.Generators.SyntaxXml/TestWriter.cs
@@ -3,10 +3,6 @@
 
 #nullable disable
 
-using System.IO;
-using System.Linq;
-using System.Threading;
-
 namespace Loretta.Generators.SyntaxXml
 {
     internal class TestWriter : AbstractFileWriter

--- a/src/Tools/Loretta.Generators.SyntaxXml/TreeFlattening.cs
+++ b/src/Tools/Loretta.Generators.SyntaxXml/TreeFlattening.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-
 namespace Loretta.Generators.SyntaxXml
 {
     public static class TreeFlattening

--- a/src/Tools/Loretta.UnusedStuffFinder/Loretta.UnusedStuffFinder.csproj
+++ b/src/Tools/Loretta.UnusedStuffFinder/Loretta.UnusedStuffFinder.csproj
@@ -1,15 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$(MSBuildThisFileDirectory)../../../build/BaseProject.props" />
-  
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
-    <IsPackable>false</IsPackable>
-    <IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tools/Loretta.UnusedStuffFinder/Loretta.UnusedStuffFinder.csproj
+++ b/src/Tools/Loretta.UnusedStuffFinder/Loretta.UnusedStuffFinder.csproj
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tools/Loretta.UnusedStuffFinder/Loretta.UnusedStuffFinder.csproj
+++ b/src/Tools/Loretta.UnusedStuffFinder/Loretta.UnusedStuffFinder.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$(MSBuildThisFileDirectory)../../../build/BaseProject.props" />
+  
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>

--- a/src/Tools/Loretta.UnusedStuffFinder/PublicApiContainer.cs
+++ b/src/Tools/Loretta.UnusedStuffFinder/PublicApiContainer.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 
 namespace Loretta.UnusedStuffFinder
 {

--- a/src/Tools/Loretta.UnusedStuffFinder/ReferenceFinder.cs
+++ b/src/Tools/Loretta.UnusedStuffFinder/ReferenceFinder.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.FindSymbols;

--- a/src/Tools/Loretta.UnusedStuffFinder/UnusedFinder.cs
+++ b/src/Tools/Loretta.UnusedStuffFinder/UnusedFinder.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Immutable;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using Microsoft.CodeAnalysis;
 using Tsu.Numerics;
 

--- a/src/Tools/LuaStatisticsCollector/DiagnosticStatistics.cs
+++ b/src/Tools/LuaStatisticsCollector/DiagnosticStatistics.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Threading;
-
-namespace Loretta.CodeAnalysis.Lua.StatisticsCollector
+﻿namespace Loretta.CodeAnalysis.Lua.StatisticsCollector
 {
     internal record DiagnosticStatistics(
         int ErrorCount,

--- a/src/Tools/LuaStatisticsCollector/GlobalStatistics.cs
+++ b/src/Tools/LuaStatisticsCollector/GlobalStatistics.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Loretta.CodeAnalysis.Collections;
+﻿using Loretta.CodeAnalysis.Collections;
 using Loretta.CodeAnalysis.Lua.StatisticsCollector.Mathematics;
 
 namespace Loretta.CodeAnalysis.Lua.StatisticsCollector

--- a/src/Tools/LuaStatisticsCollector/Loretta.CodeAnalysis.Lua.StatisticsCollector.csproj
+++ b/src/Tools/LuaStatisticsCollector/Loretta.CodeAnalysis.Lua.StatisticsCollector.csproj
@@ -1,15 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$(MSBuildThisFileDirectory)../../../build/BaseProject.props" />
-  
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <IsPackable>false</IsPackable>
-    <Nullable>enable</Nullable>
-    <!-- Treat all non-nullable reference types warnings as errors (as it should be). -->
-    <WarningsAsErrors>CS8600;CS8601;CS8602;CS8603;CS8604;CS8605;CS8607;CS8608;CS8609;CS8610;CS8611;CS8612;CS8613;CS8614;CS8615;CS8616;CS8617;CS8618;CS8619;CS8620;CS8621;CS8622;CS8624;CS8625;CS8629;CS8631;CS8633;CS8634;CS8643;CS8644;CS8645;CS8655;CS8667;CS8670;CS8714</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tools/LuaStatisticsCollector/Loretta.CodeAnalysis.Lua.StatisticsCollector.csproj
+++ b/src/Tools/LuaStatisticsCollector/Loretta.CodeAnalysis.Lua.StatisticsCollector.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$(MSBuildThisFileDirectory)../../../build/BaseProject.props" />
+  
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>

--- a/src/Tools/LuaStatisticsCollector/LuaStatisticsSyntaxWalker.cs
+++ b/src/Tools/LuaStatisticsCollector/LuaStatisticsSyntaxWalker.cs
@@ -1,6 +1,4 @@
-﻿using System.Linq;
-
-namespace Loretta.CodeAnalysis.Lua.StatisticsCollector
+﻿namespace Loretta.CodeAnalysis.Lua.StatisticsCollector
 {
     using Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax;
 
@@ -66,11 +64,11 @@ namespace Loretta.CodeAnalysis.Lua.StatisticsCollector
                                                          || !_featureStatisticsBuilder.HasUnderscoreInNumericLiterals:
                 {
                     var text = token.Text;
-                    if (!_featureStatisticsBuilder.HasBinaryNumbers && text.StartsWith("0b", System.StringComparison.OrdinalIgnoreCase))
+                    if (!_featureStatisticsBuilder.HasBinaryNumbers && text.StartsWith("0b", StringComparison.OrdinalIgnoreCase))
                         _featureStatisticsBuilder.HasBinaryNumbers = true;
-                    else if (!_featureStatisticsBuilder.HasOctalNumbers && text.StartsWith("0o", System.StringComparison.OrdinalIgnoreCase))
+                    else if (!_featureStatisticsBuilder.HasOctalNumbers && text.StartsWith("0o", StringComparison.OrdinalIgnoreCase))
                         _featureStatisticsBuilder.HasOctalNumbers = true;
-                    else if (!_featureStatisticsBuilder.HasHexFloatLiterals && text.StartsWith("0x") && (text.Contains('.') || text.Contains('p', System.StringComparison.OrdinalIgnoreCase)))
+                    else if (!_featureStatisticsBuilder.HasHexFloatLiterals && text.StartsWith("0x") && (text.Contains('.') || text.Contains('p', StringComparison.OrdinalIgnoreCase)))
                         _featureStatisticsBuilder.HasHexFloatLiterals = true;
 
                     if (!_featureStatisticsBuilder.HasUnderscoreInNumericLiterals && text.Contains('_'))
@@ -78,7 +76,7 @@ namespace Loretta.CodeAnalysis.Lua.StatisticsCollector
                 }
                 break;
 
-                case SyntaxKind.StringLiteralToken when !_featureStatisticsBuilder.HasHexEscapesInStrings && token.Text.Contains("\\x", System.StringComparison.OrdinalIgnoreCase):
+                case SyntaxKind.StringLiteralToken when !_featureStatisticsBuilder.HasHexEscapesInStrings && token.Text.Contains("\\x", StringComparison.OrdinalIgnoreCase):
                     _featureStatisticsBuilder.HasHexEscapesInStrings = true;
                     break;
 
@@ -94,8 +92,8 @@ namespace Loretta.CodeAnalysis.Lua.StatisticsCollector
         {
             switch (trivia.Kind)
             {
-                case SyntaxKind.SingleLineCommentTrivia when !_featureStatisticsBuilder.HasCComments && trivia.Text.StartsWith("//", System.StringComparison.Ordinal):
-                case SyntaxKind.MultiLineCommentTrivia when !_featureStatisticsBuilder.HasCComments && trivia.Text.StartsWith("/*", System.StringComparison.Ordinal):
+                case SyntaxKind.SingleLineCommentTrivia when !_featureStatisticsBuilder.HasCComments && trivia.Text.StartsWith("//", StringComparison.Ordinal):
+                case SyntaxKind.MultiLineCommentTrivia when !_featureStatisticsBuilder.HasCComments && trivia.Text.StartsWith("/*", StringComparison.Ordinal):
                     _featureStatisticsBuilder.HasCComments = true;
                     break;
                 case SyntaxKind.ShebangTrivia when !_featureStatisticsBuilder.HasShebang:

--- a/src/Tools/LuaStatisticsCollector/Mathematics/Statistics.cs
+++ b/src/Tools/LuaStatisticsCollector/Mathematics/Statistics.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using Loretta.CodeAnalysis.Collections;
+﻿using Loretta.CodeAnalysis.Collections;
 using Perfolizer.Mathematics.OutlierDetection;
 using Perfolizer.Mathematics.QuantileEstimators;
 

--- a/src/Tools/LuaStatisticsCollector/Program.cs
+++ b/src/Tools/LuaStatisticsCollector/Program.cs
@@ -1,13 +1,7 @@
-﻿using System;
-using System.CodeDom.Compiler;
+﻿using System.CodeDom.Compiler;
 using System.Collections.Concurrent;
-using System.Collections.Immutable;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Loretta.CodeAnalysis.Collections;
 using Loretta.CodeAnalysis.Lua.StatisticsCollector.Mathematics;
 using Loretta.CodeAnalysis.Text;

--- a/src/Tools/LuaStatisticsCollector/ReportWriter.cs
+++ b/src/Tools/LuaStatisticsCollector/ReportWriter.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Immutable;
-using System.IO;
-using System.Linq;
-using Loretta.CodeAnalysis.Lua.StatisticsCollector.Mathematics;
+﻿using Loretta.CodeAnalysis.Lua.StatisticsCollector.Mathematics;
 using NPOI.SS.UserModel;
 using NPOI.XSSF.UserModel;
 using Tsu.Numerics;


### PR DESCRIPTION
A little bit of cleanup by:

- Creating a base project properties file;
- Disable project packing by default;
- Removing redundant props from project files.

Modernizes the project by:

- Adding a preview version of the compiler (so we can use preview versions while .NET 7 preview isn't out yet);
- Enabling implicit usings and adding a few to the default set;
- Removing duplicated usings and simplifying names.