### PR TITLE
Remove References to Roblox

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,16 @@ This is (another) rewrite from scratch based on Roslyn and [The Complete Syntax 
     - C style multi line comment: `/* */`;
 3. Characters accepted as part of identifiers by LuaJIT (emojis, non-rendering characters, [or basically any byte above `127`/`0x7F`](https://github.com/LuaJIT/LuaJIT/blob/e9af1abec542e6f9851ff2368e7f196b6382a44c/src/lj_char.c#L10-L13));
 4. Luau syntax (partial):
-    - Roblox compound assignment: `+=`, `-=`, `*=`, `/=`, `^=`, `%=`, `..=`;
+    - Compound assignment: `+=`, `-=`, `*=`, `/=`, `^=`, `%=`, `..=`;
     - If expressions: `if a then b else c` and `if a then b elseif c then d else e`;
     - Typed lua syntax.
 5. FiveM's hash string syntax;
 6. Continue support. The following options are available:
     - No continue at all;
-    - Roblox's `continue` which is a contextual keyword;
+    - Luau's `continue` which is a contextual keyword;
     - Garry's Mod's `continue` which is a full fledged keyword.
 
-TL;DR: This supports Lua 5.1, Lua 5.2, Lua 5.3, Lua 5.4, LuaJIT 2.0, LuaJIT 2.1, FiveM, GLua and (partially) Luau/Roblox.
+TL;DR: This supports Lua 5.1, Lua 5.2, Lua 5.3, Lua 5.4, LuaJIT 2.0, LuaJIT 2.1, FiveM, GLua and (partially) Luau.
 
 ## Installing Loretta v0.2
 We have two NuGet packages:


### PR DESCRIPTION
Luau is completely seperate to Roblox, and is designed to run as it's own binary seperately. Therefore, all references to Roblox have been removed.