### PR TITLE
Review all presets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- [Breaking] We've reviewed the existing `LuaSyntaxOptions` presets and the following were fixed:
+	- Changed the Lua 5.1 preset to accept shebangs;
+	- Changed the Lua 5.1 preset to not accept `if` expressions;
+	- Changed the Lua 5.2 preset to accept shebangs;
+	- Changed the Lua 5.2 preset to not accept `if` expressions;
+	- Changed the Lua 5.3 preset to accept shebangs;
+	- Changed the Lua 5.3 preset to not accept `if` expressions;
+	- Changed the Lua 5.3 preset to accept floor division;
+	- Changed the Lua 5.4 preset to accept shebangs;
+	- Changed the Lua 5.4 preset to not accept `if` expressions;
+	- Changed the Lua 5.4 preset to accept floor division;
+	- Changed the LuaJIT 2.0 preset to not accept empty statements;
+	- Changed the LuaJIT 2.0 preset to accept shebangs;
+	- Changed the LuaJIT 2.1 preset to not accept empty statements;
+	- Changed the LuaJIT 2.1 preset to accept shebangs;
+	- Changed the FiveM preset to accept shebangs;
+	- Changed the FiveM preset to not accept `if` expressions;
+	- Changed the FiveM preset to accept floor division;
+	- Changed the Luau preset to not accept hex float literals;
+	- Changed the Luau preset to accept shebangs;
+	- Changed the Luau preset to not accept bitwise operators.
 
 ## v0.2.9-beta.5
 ### Added

--- a/src/Compilers/Lua/Portable/LuaSyntaxOptions.cs
+++ b/src/Compilers/Lua/Portable/LuaSyntaxOptions.cs
@@ -24,14 +24,14 @@ namespace Loretta.CodeAnalysis.Lua
             acceptHexEscapesInStrings: false,
             acceptHexFloatLiterals: false,
             acceptOctalNumbers: false,
-            acceptShebang: false,
+            acceptShebang: true,
             acceptUnderscoreInNumberLiterals: false,
             useLuaJitIdentifierRules: false,
             acceptBitwiseOperators: false,
             acceptWhitespaceEscape: false,
             acceptUnicodeEscape: false,
             continueType: ContinueType.None,
-            acceptIfExpression: true,
+            acceptIfExpression: false,
             acceptHashStrings: false,
             acceptInvalidEscapes: true,
             acceptLocalVariableAttributes: false,
@@ -41,8 +41,7 @@ namespace Loretta.CodeAnalysis.Lua
             hexIntegerFormat: IntegerFormats.NotSupported,
             acceptTypedLua: false,
             acceptFloorDivision: false,
-            acceptLuaJITNumberSuffixes: false
-        );
+            acceptLuaJITNumberSuffixes: false);
 
         /// <summary>
         /// The Lua 5.2 preset.
@@ -62,7 +61,8 @@ namespace Loretta.CodeAnalysis.Lua
             acceptBitwiseOperators: true,
             acceptUnicodeEscape: true,
             decimalIntegerFormat: IntegerFormats.Int64,
-            hexIntegerFormat: IntegerFormats.Int64);
+            hexIntegerFormat: IntegerFormats.Int64,
+            acceptFloorDivision: true);
 
         /// <summary>
         /// The Lua 5.4 preset.
@@ -77,13 +77,13 @@ namespace Loretta.CodeAnalysis.Lua
             acceptBinaryNumbers: false,
             acceptCCommentSyntax: false,
             acceptCompoundAssignment: false,
-            acceptEmptyStatements: true,
+            acceptEmptyStatements: false,
             acceptCBooleanOperators: false,
             acceptGoto: true,
             acceptHexEscapesInStrings: true,
             acceptHexFloatLiterals: true,
             acceptOctalNumbers: false,
-            acceptShebang: false,
+            acceptShebang: true,
             acceptUnderscoreInNumberLiterals: false,
             useLuaJitIdentifierRules: true,
             acceptBitwiseOperators: false,
@@ -100,8 +100,7 @@ namespace Loretta.CodeAnalysis.Lua
             hexIntegerFormat: IntegerFormats.NotSupported,
             acceptTypedLua: false,
             acceptFloorDivision: false,
-            acceptLuaJITNumberSuffixes: true
-        );
+            acceptLuaJITNumberSuffixes: true);
 
         /// <summary>
         /// The LuaJIT 2.1-beta3 preset.
@@ -129,12 +128,12 @@ namespace Loretta.CodeAnalysis.Lua
             acceptCBooleanOperators: false,
             acceptGoto: false,
             acceptHexEscapesInStrings: true,
-            acceptHexFloatLiterals: true,
+            acceptHexFloatLiterals: false,
             acceptOctalNumbers: false,
-            acceptShebang: false,
+            acceptShebang: true,
             acceptUnderscoreInNumberLiterals: true,
             useLuaJitIdentifierRules: false,
-            acceptBitwiseOperators: true,
+            acceptBitwiseOperators: false,
             acceptWhitespaceEscape: true,
             acceptUnicodeEscape: true,
             continueType: ContinueType.ContextualKeyword,
@@ -200,7 +199,9 @@ namespace Loretta.CodeAnalysis.Lua
 
         /// <summary>
         /// Same as <see cref="All"/> but with integer settings set
-        /// to <see cref="IntegerFormats.Int64"/>.
+        /// to <see cref="IntegerFormats.Int64"/>,
+        /// <see cref="AcceptFloorDivision"/> set to <see langword="true"/>
+        /// and <see cref="AcceptCCommentSyntax"/> set to <see langword="false"/>.
         /// </summary>
         public static readonly LuaSyntaxOptions AllWithIntegers = All.With(
             acceptCCommentSyntax: false,


### PR DESCRIPTION
I've reviewed the existing `LuaSyntaxOptions` presets and the following were fixed:
- Changed all the Lua, FiveM, LuaJIT and Luau presets to accept shebangs;
- Changed all the Lua and FiveM preset to not accept `if` expressions;
- Changed the Lua 5.3, 5.4 and FiveM preset to accept floor division;
- Changed all the LuaJIT presets to not accept empty statements;
- Changed the Luau preset to not accept hex float literals;
- Changed the Luau preset to accept shebangs;
- Changed the Luau preset to not accept bitwise operators.