### PR TITLE
Add complex number suffix (without tests)

### DIFF
--- a/src/Compilers/Lua/Portable/Parser/Lexer.Numbers.cs
+++ b/src/Compilers/Lua/Portable/Parser/Lexer.Numbers.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
+using System.Numerics;
 using Loretta.CodeAnalysis.Lua.Utilities;
 
 namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
@@ -55,7 +56,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                 digits++;
             }
 
-            var (isUnsignedLong, isSignedLong) = (false, false);
+            var (isUnsignedLong, isSignedLong, isComplex) = (false, false, false);
 
             if (TextWindow.AdvanceIfMatches("ULL"))
             {
@@ -65,11 +66,18 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
             {
                 isSignedLong = true;
             }
+            else if (TextWindow.AdvanceIfMatches("i"))
+            {
+                isComplex = true;
+            }
 
             if (!_options.SyntaxOptions.AcceptBinaryNumbers)
                 AddError(ErrorCode.ERR_BinaryNumericLiteralNotSupportedInVersion);
             if (!_options.SyntaxOptions.AcceptUnderscoreInNumberLiterals && hasUnderscores)
                 AddError(ErrorCode.ERR_UnderscoreInNumericLiteralNotSupportedInVersion);
+            if (!Options.SyntaxOptions.AcceptLuaJITNumberSuffixes && (isUnsignedLong || isSignedLong || isComplex))
+                AddError(ErrorCode.ERR_NumberSuffixNotSupportedInVersion);
+
             if (digits < 1)
             {
                 num = 0; // Safe default
@@ -91,6 +99,11 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
             {
                 info.ValueKind = ValueKind.Long;
                 info.LongValue = unchecked((long) num);
+            }
+            else if (isComplex)
+            {
+                info.ValueKind = ValueKind.Complex;
+                info.ComplexValue = new Complex(0, num);
             }
             else
             {
@@ -139,6 +152,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                 AddError(ErrorCode.ERR_OctalNumericLiteralNotSupportedInVersion);
             if (!_options.SyntaxOptions.AcceptUnderscoreInNumberLiterals && hasUnderscores)
                 AddError(ErrorCode.ERR_UnderscoreInNumericLiteralNotSupportedInVersion);
+
             if (digits < 1)
             {
                 num = 0; // Safe default
@@ -196,7 +210,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                 ConsumeDecimalDigits(_builder);
             }
 
-            var (isUnsignedLong, isSignedLong) = (false, false);
+            var (isUnsignedLong, isSignedLong, isComplex) = (false, false, false);
 
             if (TextWindow.AdvanceIfMatches("ULL"))
             {
@@ -220,12 +234,17 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                     isSignedLong = true;
                 }
             }
+            else if (TextWindow.AdvanceIfMatches("i"))
+            {
+                isComplex = true;
+            }
 
             info.Text = TextWindow.GetText(intern: true);
             if (!_options.SyntaxOptions.AcceptUnderscoreInNumberLiterals && info.Text.IndexOf('_') >= 0)
                 AddError(ErrorCode.ERR_UnderscoreInNumericLiteralNotSupportedInVersion);
-            if (!Options.SyntaxOptions.AcceptLuaJITNumberSuffixes && (isUnsignedLong || isSignedLong))
+            if (!Options.SyntaxOptions.AcceptLuaJITNumberSuffixes && (isUnsignedLong || isSignedLong || isComplex))
                 AddError(ErrorCode.ERR_NumberSuffixNotSupportedInVersion);
+
             if (isUnsignedLong)
             {
                 if (!ulong.TryParse(TextWindow.Intern(_builder), NumberStyles.None, CultureInfo.InvariantCulture, out var result))
@@ -242,10 +261,19 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                 info.ValueKind = ValueKind.Long;
                 info.LongValue = result;
             }
+            else if (isComplex)
+            {
+                if (!RealParser.TryParseDouble(TextWindow.Intern(_builder), out var result))
+                    AddError(ErrorCode.ERR_DoubleOverflow);
+
+                info.ValueKind = ValueKind.Complex;
+                info.ComplexValue = new Complex(0, result);
+            }
             else if (isFloat || _options.SyntaxOptions.DecimalIntegerFormat == IntegerFormats.NotSupported)
             {
                 if (!RealParser.TryParseDouble(TextWindow.Intern(_builder), out var result))
                     AddError(ErrorCode.ERR_DoubleOverflow);
+
                 info.ValueKind = ValueKind.Double;
                 info.DoubleValue = result;
             }
@@ -298,7 +326,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                 ConsumeDecimalDigits(_builder);
             }
 
-            var (isUnsignedLong, isSignedLong) = (false, false);
+            var (isUnsignedLong, isSignedLong, isComplex) = (false, false, false);
 
             if (TextWindow.AdvanceIfMatches("ULL"))
             {
@@ -322,6 +350,10 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                     isSignedLong = true;
                 }
             }
+            else if (TextWindow.AdvanceIfMatches("i"))
+            {
+                isComplex = true;
+            }
 
             info.Text = TextWindow.GetText(intern: true);
             if (!_options.SyntaxOptions.AcceptUnderscoreInNumberLiterals && info.Text.IndexOf('_') >= 0)
@@ -342,6 +374,14 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 
                 info.ValueKind = ValueKind.Long;
                 info.LongValue = result;
+            }
+            else if (isComplex)
+            {
+                if (!RealParser.TryParseDouble(TextWindow.Intern(_builder), out var result))
+                    AddError(ErrorCode.ERR_DoubleOverflow);
+
+                info.ValueKind = ValueKind.Complex;
+                info.ComplexValue = new Complex(0, result);
             }
             else if (isHexFloat || _options.SyntaxOptions.HexIntegerFormat == IntegerFormats.NotSupported)
             {

--- a/src/Compilers/Lua/Portable/Parser/Lexer.cs
+++ b/src/Compilers/Lua/Portable/Parser/Lexer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
 using System.Text;
 using Loretta.CodeAnalysis.Lua.Utilities;
 using Loretta.CodeAnalysis.Syntax.InternalSyntax;
@@ -15,7 +16,8 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
             Double,
             UInt,
             Long,
-            ULong
+            ULong,
+            Complex
         }
 
         private struct TokenInfo
@@ -30,6 +32,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
             internal uint UIntValue;
             internal long LongValue;
             internal ulong ULongValue;
+            internal Complex ComplexValue;
         }
 
         private readonly LuaParseOptions _options;
@@ -135,6 +138,7 @@ namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
                         ValueKind.Double => SyntaxFactory.Literal(leadingNode, info.Text, info.DoubleValue, trailingNode),
                         ValueKind.Long => SyntaxFactory.Literal(leadingNode, info.Text, info.LongValue, trailingNode),
                         ValueKind.ULong => SyntaxFactory.Literal(leadingNode, info.Text, info.ULongValue, trailingNode),
+                        ValueKind.Complex => SyntaxFactory.Literal(leadingNode, info.Text, info.ComplexValue, trailingNode),
                         _ => throw ExceptionUtilities.UnexpectedValue(info.ValueKind),
                     };
                     break;

--- a/src/Compilers/Lua/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Lua/Portable/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 ﻿#nullable enable
+static Loretta.CodeAnalysis.Lua.SyntaxFactory.Literal(Loretta.CodeAnalysis.SyntaxTriviaList leading, string! text, System.Numerics.Complex value, Loretta.CodeAnalysis.SyntaxTriviaList trailing) -> Loretta.CodeAnalysis.SyntaxToken
+static Loretta.CodeAnalysis.Lua.SyntaxFactory.Literal(string! text, System.Numerics.Complex value) -> Loretta.CodeAnalysis.SyntaxToken

--- a/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxFactory.cs
+++ b/src/Compilers/Lua/Portable/Syntax/InternalSyntax/SyntaxFactory.cs
@@ -1,4 +1,6 @@
-﻿namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
+﻿using System.Numerics;
+
+namespace Loretta.CodeAnalysis.Lua.Syntax.InternalSyntax
 {
     internal static partial class SyntaxFactory
     {
@@ -122,6 +124,8 @@
             SyntaxToken.WithValue(SyntaxKind.NumericLiteralToken, leading, text, value, trailing);
 
         internal static SyntaxToken Literal(GreenNode? leading, string text, ulong value, GreenNode? trailing) =>
+            SyntaxToken.WithValue(SyntaxKind.NumericLiteralToken, leading, text, value, trailing);
+        internal static SyntaxToken Literal(GreenNode? leading, string text, Complex value, GreenNode? trailing) =>
             SyntaxToken.WithValue(SyntaxKind.NumericLiteralToken, leading, text, value, trailing);
 
         internal static SyntaxToken Literal(GreenNode? leading, string text, double value, GreenNode? trailing) =>

--- a/src/Compilers/Lua/Portable/Syntax/SyntaxFactory.cs
+++ b/src/Compilers/Lua/Portable/Syntax/SyntaxFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using System.Numerics;
 using Loretta.CodeAnalysis.Lua.SymbolDisplay;
 using Loretta.CodeAnalysis.Lua.Syntax;
 using Loretta.CodeAnalysis.Syntax;
@@ -79,7 +80,7 @@ namespace Loretta.CodeAnalysis.Lua
         public static SyntaxTrivia ElasticMarker { get; } = InternalSyntax.SyntaxFactory.ElasticZeroSpace;
 
         /// <summary>
-        /// or s a trivia with kind EndOfLineTrivia containing the specified text. 
+        /// Creates a trivia with kind EndOfLineTrivia containing the specified text. 
         /// </summary>
         /// <param name="text">The text of the end of line. Any text can be specified here, however only carriage return and
         /// line feed characters are recognized by the parser as end of line.</param>
@@ -298,6 +299,14 @@ namespace Loretta.CodeAnalysis.Lua
             new(InternalSyntax.SyntaxFactory.Literal(ElasticMarker.UnderlyingNode, text, value, ElasticMarker.UnderlyingNode));
 
         /// <summary>
+        /// Creates a token with kind NumericLiteralToken from the text and corresponding complex value.
+        /// </summary>
+        /// <param name="text">The raw text of the literal.</param>
+        /// <param name="value">The complex value to be represented by the returned token.</param>
+        public static SyntaxToken Literal(string text, Complex value) =>
+            new(InternalSyntax.SyntaxFactory.Literal(ElasticMarker.UnderlyingNode, text, value, ElasticMarker.UnderlyingNode));
+
+        /// <summary>
         /// Creates a token with kind NumericLiteralToken from the text and corresponding 8-byte floating point value.
         /// </summary>
         /// <param name="leading">A list of trivia immediately preceding the token.</param>
@@ -305,6 +314,16 @@ namespace Loretta.CodeAnalysis.Lua
         /// <param name="value">The 8-byte unsigned integer value to be represented by the returned token.</param>
         /// <param name="trailing">A list of trivia immediately following the token.</param>
         public static SyntaxToken Literal(SyntaxTriviaList leading, string text, ulong value, SyntaxTriviaList trailing) =>
+            new(InternalSyntax.SyntaxFactory.Literal(leading.Node, text, value, trailing.Node));
+
+        /// <summary>
+        /// Creates a token with kind NumericLiteralToken from the text and corresponding complex value.
+        /// </summary>
+        /// <param name="leading">A list of trivia immediately preceding the token.</param>
+        /// <param name="text">The raw text of the literal.</param>
+        /// <param name="value">The complex value to be represented by the returned token.</param>
+        /// <param name="trailing">A list of trivia immediately following the token.</param>
+        public static SyntaxToken Literal(SyntaxTriviaList leading, string text, Complex value, SyntaxTriviaList trailing) =>
             new(InternalSyntax.SyntaxFactory.Literal(leading.Node, text, value, trailing.Node));
 
         /// <summary>

--- a/src/Compilers/Lua/Test/Portable/Lexical/LexicalTestData.cs
+++ b/src/Compilers/Lua/Test/Portable/Lexical/LexicalTestData.cs
@@ -182,7 +182,6 @@ namespace Loretta.CodeAnalysis.Lua.UnitTests.Lexical
                     ulong.Parse(text[2..^3], NumberStyles.HexNumber));
             }
 
-
             // Hexadecimal
             foreach (var text in new[]
             {


### PR DESCRIPTION
LuaJIT (with FFI support enabled) has the i suffix for numbers.

i for complex numbers

Requested by @bmcq-0.

Fixes https://github.com/GGG-KILLER/Loretta/issues/72