### PR TITLE
ci: Modernize

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: dotnet-sdk
+    directory: /
+    assignees:
+      - "@LorettaDevs/core"
+    commit-message:
+      prefix: chore
+      include: scope
+    schedule:
+      interval: weekly
+      day: friday
+  - package-ecosystem: github-actions
+    directory: /
+    assignees:
+      - "@LorettaDevs/core"
+    commit-message:
+      prefix: ci
+      include: scope
+    schedule:
+      interval: weekly
+      day: friday

--- a/.github/workflows/nigthly-publish.yml
+++ b/.github/workflows/nigthly-publish.yml
@@ -23,26 +23,20 @@ jobs:
       no-prefix-version: ${{ steps.gen-version.outputs.NO_PREFIX_VERSION }}
       has-nightly: ${{ steps.gen-version.outputs.HAS_NIGHTLY }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
-
       - name: Extract Latest Changes
         run: ./build/Extract-LatestChanges.ps1
         shell: pwsh
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+      - uses: actions/setup-dotnet@v5.1.0
         with:
           dotnet-version: 8.0.x
-
       - name: Generate Version Number
         id: gen-version
         run: |
           dotnet run --project src/Tools/NightlyTool --verbosity quiet -- $env:GITHUB_OUTPUT
         shell: pwsh
-
       - name: Tag New Nightly
         if: steps.gen-version.outputs.HAS_NIGHTLY == 'yes'
         run: |
@@ -50,7 +44,6 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag --annotate --file=LATESTCHANGES.md --cleanup=whitespace ${{ steps.gen-version.outputs.VERSION }}
           git push origin ${{ steps.gen-version.outputs.VERSION }}
-        shell: pwsh
 
   release:
     name: Release
@@ -62,39 +55,38 @@ jobs:
       contents: write # Allow to checkout (read) and make new releases (write)
     if: needs.extract-nightly-info.outputs.has-nightly == 'yes'
     steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Setup .NET
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-dotnet@v5.1.0
         with:
           dotnet-version: |
             8.0.x
             9.0.x
-
-      - name: Install dependencies
-        run: dotnet restore
-
-      - name: Build
-        run: dotnet build --no-restore --configuration Release -p:Version=${{ needs.extract-nightly-info.outputs.no-prefix-version }}
-
-      - name: Generate NuGet packages
-        run: dotnet pack --no-restore --configuration Release --output ./packages --include-symbols -p:SymbolPackageFormat=snupkg -p:Version=${{ needs.extract-nightly-info.outputs.no-prefix-version }}
-
-      - name: Publish packages
+            10.0.x
+      - name: Package Libraries
         run: |
-          Get-ChildItem -Path ./packages/ -Filter *.nupkg -File -Name | ForEach-Object {
-            dotnet nuget push ./packages/$_ --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
-          }
-        shell: pwsh
-
+          dotnet pack \
+            --configuration Release \
+            --output ./packages \
+            --include-symbols \
+            -p:Version=${{ needs.extract-nightly-info.outputs.no-prefix-version }}
+        shell: bash
+      - name: Get a short-lived NuGet API key
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+      - name: Publish Packages to NuGet
+        run: |
+          dotnet nuget push ./packages/*.nupkg \
+            --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate
+        shell: bash
       - name: Extract Latest Changes
         run: ./build/Extract-LatestChanges.ps1
         shell: pwsh
-
       - name: Create Release
-        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2.5.0
         with:
           name: ${{ needs.extract-nightly-info.outputs.full-version }}
           tag_name: ${{ needs.extract-nightly-info.outputs.full-version }}

--- a/.github/workflows/stable-publish.yml
+++ b/.github/workflows/stable-publish.yml
@@ -19,35 +19,37 @@ jobs:
     permissions:
       contents: write # Allow checkout (read) and release creation (write)
     steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Setup .NET
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-dotnet@v5.1.0
         with:
           dotnet-version: |
             8.0.x
             9.0.x
-
-      - name: Install dependencies
-        run: dotnet restore
-      - name: Build
-        run: dotnet build --configuration Release --no-restore
-      - name: Generate NuGet packages
-        run: dotnet pack --configuration Release --output ./packages --no-restore --include-symbols -p:SymbolPackageFormat=snupkg
-      - name: Publish packages
+            10.0.x
+      - name: Package Libraries
         run: |
-          Get-ChildItem -Path ./packages/ -Filter *.nupkg -File -Name | ForEach-Object {
-            dotnet nuget push ./packages/$_ --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
-          }
-        shell: pwsh
-
+          dotnet pack \
+            --configuration Release \
+            --output ./packages \
+            --include-symbols
+        shell: bash
+      - name: Get a short-lived NuGet API key
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+      - name: Publish Packages to NuGet
+        run: |
+          dotnet nuget push ./packages/*.nupkg \
+            --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate
+        shell: bash
       - name: Extract Latest Changes
         run: ./build/Extract-LatestChanges.ps1
         shell: pwsh
       - name: Create Release
-        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2.5.0
         with:
           body_path: LATESTCHANGES.md
           prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'alpha') }}


### PR DESCRIPTION
Modernizes the publishing flow to use Short Lived Tokens using [NuGet.org Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing). This should free us from having to generate new API keys every so often.

Also adds dependabot dependency updates to ensure that we don't have any outdated or vulnerable dependencies either on the .NET library or in the actions used in our GHA workflows.
