### PR TITLE
Fixes issue with slot release / slot allocation with certain dead code

### DIFF
--- a/src/Compilers/Lua/Experimental/Minifying/SortedSlotAllocator.cs
+++ b/src/Compilers/Lua/Experimental/Minifying/SortedSlotAllocator.cs
@@ -25,10 +25,6 @@
         }
 
         /// <inheritdoc/>
-        public void ReleaseSlot(int slot)
-        {
-            if (!_freeSlots.Add(slot))
-                throw new InvalidOperationException($"Slot {slot} was released two times.");
-        }
+        public void ReleaseSlot(int slot) => _freeSlots.Add(slot);
     }
 }


### PR DESCRIPTION
Fixes issues with minifying certain "dead" code with some obfuscators. It is no problem to release a slot twice. All tests run OK with this change.

